### PR TITLE
Implement all miekg/pkcs11 Ctx functions

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -14,14 +14,62 @@ type Backend interface {
 	GetSlotList(bool) ([]uint, error)
 	GetSlotInfo(uint) (pkcs11.SlotInfo, error)
 	GetTokenInfo(uint) (pkcs11.TokenInfo, error)
-	GetMechanismList(slotID uint) ([]*pkcs11.Mechanism, error)
+	GetMechanismList(uint) ([]*pkcs11.Mechanism, error)
+	GetMechanismInfo(uint, []*pkcs11.Mechanism) (pkcs11.MechanismInfo, error)
+	InitPIN(pkcs11.SessionHandle, string) error
+	SetPIN(pkcs11.SessionHandle, string, string) error
 	OpenSession(uint, uint) (pkcs11.SessionHandle, error)
 	CloseSession(pkcs11.SessionHandle) error
+	CloseAllSessions(uint) error
+	GetSessionInfo(pkcs11.SessionHandle) (pkcs11.SessionInfo, error)
+	GetOperationState(pkcs11.SessionHandle) ([]byte, error)
+	SetOperationState(pkcs11.SessionHandle, []byte, pkcs11.ObjectHandle, pkcs11.ObjectHandle) error
 	Login(pkcs11.SessionHandle, uint, string) error
 	Logout(pkcs11.SessionHandle) error
+	CreateObject(pkcs11.SessionHandle, []*pkcs11.Attribute) (pkcs11.ObjectHandle, error)
+	CopyObject(pkcs11.SessionHandle, pkcs11.ObjectHandle, []*pkcs11.Attribute) (pkcs11.ObjectHandle, error)
+	DestroyObject(pkcs11.SessionHandle, pkcs11.ObjectHandle) error
 	GetObjectSize(pkcs11.SessionHandle, pkcs11.ObjectHandle) (uint, error)
 	GetAttributeValue(pkcs11.SessionHandle, pkcs11.ObjectHandle, []*pkcs11.Attribute) ([]*pkcs11.Attribute, error)
+	SetAttributeValue(pkcs11.SessionHandle, pkcs11.ObjectHandle, []*pkcs11.Attribute) error
 	FindObjectsInit(pkcs11.SessionHandle, []*pkcs11.Attribute) error
 	FindObjects(pkcs11.SessionHandle, int) ([]pkcs11.ObjectHandle, bool, error)
 	FindObjectsFinal(pkcs11.SessionHandle) error
+	EncryptInit(pkcs11.SessionHandle, []*pkcs11.Mechanism, pkcs11.ObjectHandle) error
+	Encrypt(pkcs11.SessionHandle, []byte) ([]byte, error)
+	EncryptUpdate(pkcs11.SessionHandle, []byte) ([]byte, error)
+	EncryptFinal(pkcs11.SessionHandle) ([]byte, error)
+	DecryptInit(pkcs11.SessionHandle, []*pkcs11.Mechanism, pkcs11.ObjectHandle) error
+	Decrypt(pkcs11.SessionHandle, []byte) ([]byte, error)
+	DecryptUpdate(pkcs11.SessionHandle, []byte) ([]byte, error)
+	DecryptFinal(pkcs11.SessionHandle) ([]byte, error)
+	DigestInit(pkcs11.SessionHandle, []*pkcs11.Mechanism) error
+	Digest(pkcs11.SessionHandle, []byte) ([]byte, error)
+	DigestUpdate(pkcs11.SessionHandle, []byte) error
+	DigestKey(pkcs11.SessionHandle, pkcs11.ObjectHandle) error
+	DigestFinal(pkcs11.SessionHandle) ([]byte, error)
+	SignInit(pkcs11.SessionHandle, []*pkcs11.Mechanism, pkcs11.ObjectHandle) error
+	Sign(pkcs11.SessionHandle, []byte) ([]byte, error)
+	SignUpdate(pkcs11.SessionHandle, []byte) error
+	SignFinal(pkcs11.SessionHandle) ([]byte, error)
+	SignRecoverInit(pkcs11.SessionHandle, []*pkcs11.Mechanism, pkcs11.ObjectHandle) error
+	SignRecover(pkcs11.SessionHandle, []byte) ([]byte, error)
+	VerifyInit(pkcs11.SessionHandle, []*pkcs11.Mechanism, pkcs11.ObjectHandle) error
+	Verify(pkcs11.SessionHandle, []byte, []byte) error
+	VerifyUpdate(pkcs11.SessionHandle, []byte) error
+	VerifyFinal(pkcs11.SessionHandle, []byte) error
+	VerifyRecoverInit(pkcs11.SessionHandle, []*pkcs11.Mechanism, pkcs11.ObjectHandle) error
+	VerifyRecover(pkcs11.SessionHandle, []byte) ([]byte, error)
+	DigestEncryptUpdate(pkcs11.SessionHandle, []byte) ([]byte, error)
+	DecryptDigestUpdate(pkcs11.SessionHandle, []byte) ([]byte, error)
+	SignEncryptUpdate(pkcs11.SessionHandle, []byte) ([]byte, error)
+	DecryptVerifyUpdate(pkcs11.SessionHandle, []byte) ([]byte, error)
+	GenerateKey(pkcs11.SessionHandle, []*pkcs11.Mechanism, []*pkcs11.Attribute) (pkcs11.ObjectHandle, error)
+	GenerateKeyPair(pkcs11.SessionHandle, []*pkcs11.Mechanism, []*pkcs11.Attribute, []*pkcs11.Attribute) (pkcs11.ObjectHandle, pkcs11.ObjectHandle, error)
+	WrapKey(pkcs11.SessionHandle, []*pkcs11.Mechanism, pkcs11.ObjectHandle, pkcs11.ObjectHandle) ([]byte, error)
+	UnwrapKey(pkcs11.SessionHandle, []*pkcs11.Mechanism, pkcs11.ObjectHandle, []byte, []*pkcs11.Attribute) (pkcs11.ObjectHandle, error)
+	DeriveKey(pkcs11.SessionHandle, []*pkcs11.Mechanism, pkcs11.ObjectHandle, []*pkcs11.Attribute) (pkcs11.ObjectHandle, error)
+	SeedRandom(pkcs11.SessionHandle, []byte) error
+	GenerateRandom(pkcs11.SessionHandle, int) ([]byte, error)
+	WaitForSlotEvent(uint) chan pkcs11.SlotEvent
 }

--- a/pkcs11_exported.c
+++ b/pkcs11_exported.c
@@ -11,16 +11,63 @@ CK_RV Go_GetSlotList(CK_BBOOL, CK_SLOT_ID_PTR, CK_ULONG_PTR);
 CK_RV Go_GetSlotInfo(CK_SLOT_ID, CK_SLOT_INFO_PTR);
 CK_RV Go_GetTokenInfo(CK_SLOT_ID, CK_TOKEN_INFO_PTR);
 CK_RV Go_GetMechanismList(CK_SLOT_ID, CK_MECHANISM_TYPE_PTR, CK_ULONG_PTR);
+CK_RV Go_GetMechanismInfo(CK_SLOT_ID, CK_MECHANISM_TYPE, CK_MECHANISM_INFO_PTR);
+CK_RV Go_InitPIN(CK_SESSION_HANDLE, CK_UTF8CHAR_PTR, CK_ULONG);
+CK_RV Go_SetPIN(CK_SESSION_HANDLE, CK_UTF8CHAR_PTR, CK_ULONG, CK_UTF8CHAR_PTR, CK_ULONG);
 CK_RV Go_OpenSession(CK_SLOT_ID, CK_FLAGS, CK_SESSION_HANDLE_PTR);
 CK_RV Go_CloseSession(CK_SESSION_HANDLE);
+CK_RV Go_CloseAllSessions(CK_SLOT_ID);
+CK_RV Go_GetSessionInfo(CK_SESSION_HANDLE,CK_SESSION_INFO_PTR);
+CK_RV Go_GetOperationState(CK_SESSION_HANDLE , CK_BYTE_PTR , CK_ULONG_PTR);
+CK_RV Go_SetOperationState(CK_SESSION_HANDLE, CK_BYTE_PTR , CK_ULONG , CK_OBJECT_HANDLE , CK_OBJECT_HANDLE );
 CK_RV Go_Login(CK_SESSION_HANDLE, CK_USER_TYPE, CK_UTF8CHAR_PTR, CK_ULONG);
 CK_RV Go_Logout(CK_SESSION_HANDLE);
+CK_RV Go_CreateObject(CK_SESSION_HANDLE, CK_ATTRIBUTE_PTR , CK_ULONG , CK_OBJECT_HANDLE_PTR );
+CK_RV Go_CopyObject(CK_SESSION_HANDLE, CK_OBJECT_HANDLE ,CK_ATTRIBUTE_PTR , CK_ULONG ,CK_OBJECT_HANDLE_PTR );
+CK_RV Go_DestroyObject(CK_SESSION_HANDLE, CK_OBJECT_HANDLE );
 CK_RV Go_GetObjectSize(CK_SESSION_HANDLE, CK_OBJECT_HANDLE, CK_ULONG_PTR);
 CK_RV Go_GetAttributeValue(CK_SESSION_HANDLE, CK_OBJECT_HANDLE, CK_ATTRIBUTE_PTR, CK_ULONG);
+CK_RV Go_SetAttributeValue(CK_SESSION_HANDLE, CK_OBJECT_HANDLE, CK_ATTRIBUTE_PTR, CK_ULONG);
 CK_RV Go_FindObjectsInit(CK_SESSION_HANDLE, CK_ATTRIBUTE_PTR, CK_ULONG);
 CK_RV Go_FindObjects(CK_SESSION_HANDLE, CK_OBJECT_HANDLE_PTR, CK_ULONG, CK_ULONG_PTR);
 CK_RV Go_FindObjectsFinal(CK_SESSION_HANDLE);
-
+CK_RV Go_EncryptInit(CK_SESSION_HANDLE,CK_MECHANISM_PTR,CK_OBJECT_HANDLE);
+CK_RV Go_Encrypt(CK_SESSION_HANDLE,CK_BYTE_PTR,CK_ULONG,CK_BYTE_PTR,CK_ULONG_PTR);
+CK_RV Go_EncryptUpdate(CK_SESSION_HANDLE,CK_BYTE_PTR,CK_ULONG,CK_BYTE_PTR,CK_ULONG_PTR);
+CK_RV Go_EncryptFinal(CK_SESSION_HANDLE,CK_BYTE_PTR,CK_ULONG_PTR);
+CK_RV Go_DecryptInit(CK_SESSION_HANDLE,CK_MECHANISM_PTR,CK_OBJECT_HANDLE);
+CK_RV Go_Decrypt(CK_SESSION_HANDLE,CK_BYTE_PTR,CK_ULONG,CK_BYTE_PTR,CK_ULONG_PTR);
+CK_RV Go_DecryptUpdate(CK_SESSION_HANDLE,CK_BYTE_PTR,CK_ULONG,CK_BYTE_PTR,CK_ULONG_PTR);
+CK_RV Go_DecryptFinal(CK_SESSION_HANDLE,CK_BYTE_PTR,CK_ULONG_PTR);
+CK_RV Go_DigestInit(CK_SESSION_HANDLE,CK_MECHANISM_PTR);
+CK_RV Go_Digest(CK_SESSION_HANDLE,CK_BYTE_PTR,CK_ULONG,CK_BYTE_PTR,CK_ULONG_PTR);
+CK_RV Go_DigestUpdate(CK_SESSION_HANDLE,CK_BYTE_PTR,CK_ULONG);
+CK_RV Go_DigestKey(CK_SESSION_HANDLE,CK_OBJECT_HANDLE);
+CK_RV Go_DigestFinal(CK_SESSION_HANDLE,CK_BYTE_PTR,CK_ULONG_PTR);
+CK_RV Go_SignInit(CK_SESSION_HANDLE, CK_MECHANISM_PTR, CK_OBJECT_HANDLE);
+CK_RV Go_SignUpdate(CK_SESSION_HANDLE, CK_BYTE_PTR, CK_ULONG);
+CK_RV Go_Sign(CK_SESSION_HANDLE, CK_BYTE_PTR, CK_ULONG, CK_BYTE_PTR, CK_ULONG_PTR);
+CK_RV Go_SignFinal(CK_SESSION_HANDLE, CK_BYTE_PTR, CK_ULONG_PTR);
+CK_RV Go_SignRecoverInit(CK_SESSION_HANDLE,CK_MECHANISM_PTR,CK_OBJECT_HANDLE);
+CK_RV Go_SignRecover(CK_SESSION_HANDLE,CK_BYTE_PTR,CK_ULONG,CK_BYTE_PTR,CK_ULONG_PTR);
+CK_RV Go_VerifyInit(CK_SESSION_HANDLE,CK_MECHANISM_PTR,CK_OBJECT_HANDLE);
+CK_RV Go_Verify(CK_SESSION_HANDLE,CK_BYTE_PTR,CK_ULONG,CK_BYTE_PTR,CK_ULONG);
+CK_RV Go_VerifyUpdate(CK_SESSION_HANDLE,CK_BYTE_PTR,CK_ULONG);
+CK_RV Go_VerifyFinal(CK_SESSION_HANDLE,CK_BYTE_PTR,CK_ULONG);
+CK_RV Go_VerifyRecoverInit(CK_SESSION_HANDLE,CK_MECHANISM_PTR,CK_OBJECT_HANDLE);
+CK_RV Go_VerifyRecover(CK_SESSION_HANDLE,CK_BYTE_PTR,CK_ULONG,CK_BYTE_PTR,CK_ULONG_PTR);
+CK_RV Go_DigestEncryptUpdate(CK_SESSION_HANDLE,CK_BYTE_PTR,CK_ULONG,CK_BYTE_PTR,CK_ULONG_PTR);
+CK_RV Go_DecryptDigestUpdate(CK_SESSION_HANDLE,CK_BYTE_PTR,CK_ULONG,CK_BYTE_PTR,CK_ULONG_PTR);
+CK_RV Go_SignEncryptUpdate(CK_SESSION_HANDLE,CK_BYTE_PTR,CK_ULONG,CK_BYTE_PTR,CK_ULONG_PTR);
+CK_RV Go_DecryptVerifyUpdate(CK_SESSION_HANDLE,CK_BYTE_PTR,CK_ULONG,CK_BYTE_PTR,CK_ULONG_PTR);
+CK_RV Go_GenerateKey(CK_SESSION_HANDLE,CK_MECHANISM_PTR,CK_ATTRIBUTE_PTR,CK_ULONG,CK_OBJECT_HANDLE_PTR);
+CK_RV Go_GenerateKeyPair(CK_SESSION_HANDLE,CK_MECHANISM_PTR,CK_ATTRIBUTE_PTR,CK_ULONG,CK_ATTRIBUTE_PTR,CK_ULONG,CK_OBJECT_HANDLE_PTR,CK_OBJECT_HANDLE_PTR);
+CK_RV Go_WrapKey(CK_SESSION_HANDLE,CK_MECHANISM_PTR,CK_OBJECT_HANDLE,CK_OBJECT_HANDLE,CK_BYTE_PTR,CK_ULONG_PTR);
+CK_RV Go_UnwrapKey(CK_SESSION_HANDLE,CK_MECHANISM_PTR,CK_OBJECT_HANDLE,CK_BYTE_PTR,CK_ULONG,CK_ATTRIBUTE_PTR,CK_ULONG,CK_OBJECT_HANDLE_PTR);
+CK_RV Go_DeriveKey(CK_SESSION_HANDLE,CK_MECHANISM_PTR,CK_OBJECT_HANDLE,CK_ATTRIBUTE_PTR,CK_ULONG,CK_OBJECT_HANDLE_PTR);
+CK_RV Go_SeedRandom(CK_SESSION_HANDLE,CK_BYTE_PTR,CK_ULONG);
+CK_RV Go_GenerateRandom(CK_SESSION_HANDLE,CK_BYTE_PTR,CK_ULONG);
+CK_RV Go_WaitForSlotEvent(CK_FLAGS,CK_SLOT_ID_PTR,CK_VOID_PTR);
 void GoLog(const char*);
 
 CK_FUNCTION_LIST pkcs11_functions = 
@@ -166,29 +213,25 @@ CK_DEFINE_FUNCTION(CK_RV, C_GetMechanismList)(CK_SLOT_ID slotID, CK_MECHANISM_TY
 
 CK_DEFINE_FUNCTION(CK_RV, C_GetMechanismInfo)(CK_SLOT_ID slotID, CK_MECHANISM_TYPE type, CK_MECHANISM_INFO_PTR pInfo)
 {
-	GoLog("C_GetMechanismInfo");
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_GetMechanismInfo(slotID, type, pInfo);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_InitToken)(CK_SLOT_ID slotID, CK_UTF8CHAR_PTR pPin, CK_ULONG ulPinLen, CK_UTF8CHAR_PTR pLabel)
 {
-	GoLog("C_InitToken");
 	return CKR_FUNCTION_NOT_SUPPORTED;
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_InitPIN)(CK_SESSION_HANDLE hSession, CK_UTF8CHAR_PTR pPin, CK_ULONG ulPinLen)
 {
-	GoLog("C_InitPIN");
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_InitPIN(hSession, pPin, ulPinLen);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_SetPIN)(CK_SESSION_HANDLE hSession, CK_UTF8CHAR_PTR pOldPin, CK_ULONG ulOldLen, CK_UTF8CHAR_PTR pNewPin, CK_ULONG ulNewLen)
 {
-	GoLog("C_SetPIN");
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_SetPIN(hSession, pOldPin, ulOldLen, pNewPin, ulNewLen);
 }
 
 
@@ -206,30 +249,26 @@ CK_DEFINE_FUNCTION(CK_RV, C_CloseSession)(CK_SESSION_HANDLE hSession)
 
 CK_DEFINE_FUNCTION(CK_RV, C_CloseAllSessions)(CK_SLOT_ID slotID)
 {	
-	GoLog("C_CloseAllSessions");
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_CloseAllSessions(slotID);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_GetSessionInfo)(CK_SESSION_HANDLE hSession, CK_SESSION_INFO_PTR pInfo)
 {
-	GoLog("C_GetSessionInfo");
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_GetSessionInfo(hSession, pInfo);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_GetOperationState)(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pOperationState, CK_ULONG_PTR pulOperationStateLen)
 {
-	GoLog("C_GetOperationState");
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_GetOperationState(hSession, pOperationState, pulOperationStateLen);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_SetOperationState)(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pOperationState, CK_ULONG ulOperationStateLen, CK_OBJECT_HANDLE hEncryptionKey, CK_OBJECT_HANDLE hAuthenticationKey)
 {
 
-	GoLog("C_SetOperationState");
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_SetOperationState(hSession, pOperationState, ulOperationStateLen, hEncryptionKey, hAuthenticationKey);
 }
 
 
@@ -247,19 +286,19 @@ CK_DEFINE_FUNCTION(CK_RV, C_Logout)(CK_SESSION_HANDLE hSession)
 
 CK_DEFINE_FUNCTION(CK_RV, C_CreateObject)(CK_SESSION_HANDLE hSession, CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount, CK_OBJECT_HANDLE_PTR phObject)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_CreateObject(hSession, pTemplate, ulCount, phObject);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_CopyObject)(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hObject, CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount, CK_OBJECT_HANDLE_PTR phNewObject)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_CopyObject(hSession, hObject, pTemplate, ulCount, phNewObject);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_DestroyObject)(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hObject)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_DestroyObject(hSession, hObject);
 }
 
 
@@ -277,7 +316,7 @@ CK_DEFINE_FUNCTION(CK_RV, C_GetAttributeValue)(CK_SESSION_HANDLE hSession, CK_OB
 
 CK_DEFINE_FUNCTION(CK_RV, C_SetAttributeValue)(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hObject, CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_SetAttributeValue(hSession, hObject, pTemplate, ulCount);
 }
 
 
@@ -301,217 +340,217 @@ CK_DEFINE_FUNCTION(CK_RV, C_FindObjectsFinal)(CK_SESSION_HANDLE hSession)
 
 CK_DEFINE_FUNCTION(CK_RV, C_EncryptInit)(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_EncryptInit(hSession, pMechanism, hKey);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_Encrypt)(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData, CK_ULONG ulDataLen, CK_BYTE_PTR pEncryptedData, CK_ULONG_PTR pulEncryptedDataLen)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_Encrypt(hSession, pData, ulDataLen, pEncryptedData, pulEncryptedDataLen);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_EncryptUpdate)(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pPart, CK_ULONG ulPartLen, CK_BYTE_PTR pEncryptedPart, CK_ULONG_PTR pulEncryptedPartLen)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_EncryptUpdate(hSession, pPart, ulPartLen, pEncryptedPart, pulEncryptedPartLen);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_EncryptFinal)(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pLastEncryptedPart, CK_ULONG_PTR pulLastEncryptedPartLen)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_EncryptFinal(hSession, pLastEncryptedPart, pulLastEncryptedPartLen);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_DecryptInit)(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_DecryptInit(hSession, pMechanism, hKey);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_Decrypt)(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pEncryptedData, CK_ULONG ulEncryptedDataLen, CK_BYTE_PTR pData, CK_ULONG_PTR pulDataLen)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_Decrypt(hSession, pEncryptedData, ulEncryptedDataLen, pData, pulDataLen);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_DecryptUpdate)(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pEncryptedPart, CK_ULONG ulEncryptedPartLen, CK_BYTE_PTR pPart, CK_ULONG_PTR pulPartLen)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_DecryptUpdate(hSession, pEncryptedPart, ulEncryptedPartLen, pPart, pulPartLen);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_DecryptFinal)(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pLastPart, CK_ULONG_PTR pulLastPartLen)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_DecryptFinal(hSession, pLastPart, pulLastPartLen);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_DigestInit)(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_DigestInit(hSession, pMechanism);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_Digest)(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData, CK_ULONG ulDataLen, CK_BYTE_PTR pDigest, CK_ULONG_PTR pulDigestLen)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_Digest(hSession, pData, ulDataLen, pDigest, pulDigestLen);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_DigestUpdate)(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pPart, CK_ULONG ulPartLen)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_DigestUpdate(hSession, pPart, ulPartLen);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_DigestKey)(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hKey)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_DigestKey(hSession, hKey);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_DigestFinal)(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pDigest, CK_ULONG_PTR pulDigestLen)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_DigestFinal(hSession, pDigest, pulDigestLen);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_SignInit)(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_SignInit(hSession, pMechanism, hKey);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_Sign)(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData, CK_ULONG ulDataLen, CK_BYTE_PTR pSignature, CK_ULONG_PTR pulSignatureLen)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_Sign(hSession, pData, ulDataLen, pSignature, pulSignatureLen);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_SignUpdate)(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pPart, CK_ULONG ulPartLen)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_SignUpdate(hSession, pPart, ulPartLen);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_SignFinal)(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pSignature, CK_ULONG_PTR pulSignatureLen)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_SignFinal(hSession, pSignature, pulSignatureLen);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_SignRecoverInit)(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_SignRecoverInit(hSession, pMechanism, hKey);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_SignRecover)(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData, CK_ULONG ulDataLen, CK_BYTE_PTR pSignature, CK_ULONG_PTR pulSignatureLen)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_SignRecover(hSession, pData, ulDataLen, pSignature, pulSignatureLen);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_VerifyInit)(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_VerifyInit(hSession, pMechanism, hKey);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_Verify)(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData, CK_ULONG ulDataLen, CK_BYTE_PTR pSignature, CK_ULONG ulSignatureLen)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_Verify(hSession, pData, ulDataLen, pSignature, ulSignatureLen);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_VerifyUpdate)(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pPart, CK_ULONG ulPartLen)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_VerifyUpdate(hSession, pPart, ulPartLen);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_VerifyFinal)(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pSignature, CK_ULONG ulSignatureLen)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_VerifyFinal(hSession, pSignature, ulSignatureLen);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_VerifyRecoverInit)(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hKey)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_VerifyRecoverInit(hSession, pMechanism, hKey);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_VerifyRecover)(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pSignature, CK_ULONG ulSignatureLen, CK_BYTE_PTR pData, CK_ULONG_PTR pulDataLen)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_VerifyRecover(hSession, pSignature, ulSignatureLen, pData, pulDataLen);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_DigestEncryptUpdate)(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pPart, CK_ULONG ulPartLen, CK_BYTE_PTR pEncryptedPart, CK_ULONG_PTR pulEncryptedPartLen)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_DigestEncryptUpdate(hSession, pPart, ulPartLen, pEncryptedPart, pulEncryptedPartLen);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_DecryptDigestUpdate)(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pEncryptedPart, CK_ULONG ulEncryptedPartLen, CK_BYTE_PTR pPart, CK_ULONG_PTR pulPartLen)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_DecryptDigestUpdate(hSession, pEncryptedPart, ulEncryptedPartLen, pPart, pulPartLen);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_SignEncryptUpdate)(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pPart, CK_ULONG ulPartLen, CK_BYTE_PTR pEncryptedPart, CK_ULONG_PTR pulEncryptedPartLen)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_SignEncryptUpdate(hSession, pPart, ulPartLen, pEncryptedPart, pulEncryptedPartLen);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_DecryptVerifyUpdate)(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pEncryptedPart, CK_ULONG ulEncryptedPartLen, CK_BYTE_PTR pPart, CK_ULONG_PTR pulPartLen)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_DecryptVerifyUpdate(hSession, pEncryptedPart, ulEncryptedPartLen, pPart, pulPartLen);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_GenerateKey)(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount, CK_OBJECT_HANDLE_PTR phKey)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_GenerateKey(hSession, pMechanism, pTemplate, ulCount, phKey);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_GenerateKeyPair)(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_ATTRIBUTE_PTR pPublicKeyTemplate, CK_ULONG ulPublicKeyAttributeCount, CK_ATTRIBUTE_PTR pPrivateKeyTemplate, CK_ULONG ulPrivateKeyAttributeCount, CK_OBJECT_HANDLE_PTR phPublicKey, CK_OBJECT_HANDLE_PTR phPrivateKey)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_GenerateKeyPair(hSession, pMechanism, pPublicKeyTemplate, ulPublicKeyAttributeCount, pPrivateKeyTemplate, ulPrivateKeyAttributeCount, phPublicKey, phPrivateKey);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_WrapKey)(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hWrappingKey, CK_OBJECT_HANDLE hKey, CK_BYTE_PTR pWrappedKey, CK_ULONG_PTR pulWrappedKeyLen)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_WrapKey(hSession, pMechanism, hWrappingKey, hKey, pWrappedKey, pulWrappedKeyLen);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_UnwrapKey)(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hUnwrappingKey, CK_BYTE_PTR pWrappedKey, CK_ULONG ulWrappedKeyLen, CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulAttributeCount, CK_OBJECT_HANDLE_PTR phKey)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_UnwrapKey(hSession, pMechanism, hUnwrappingKey, pWrappedKey, ulWrappedKeyLen, pTemplate, ulAttributeCount, phKey);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_DeriveKey)(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism, CK_OBJECT_HANDLE hBaseKey, CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulAttributeCount, CK_OBJECT_HANDLE_PTR phKey)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_DeriveKey(hSession, pMechanism, hBaseKey, pTemplate, ulAttributeCount, phKey);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_SeedRandom)(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pSeed, CK_ULONG ulSeedLen)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_SeedRandom(hSession, pSeed, ulSeedLen);
 }
 
 
 CK_DEFINE_FUNCTION(CK_RV, C_GenerateRandom)(CK_SESSION_HANDLE hSession, CK_BYTE_PTR RandomData, CK_ULONG ulRandomLen)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_GenerateRandom(hSession, RandomData, ulRandomLen);
 }
 
 
@@ -529,5 +568,5 @@ CK_DEFINE_FUNCTION(CK_RV, C_CancelFunction)(CK_SESSION_HANDLE hSession)
 
 CK_DEFINE_FUNCTION(CK_RV, C_WaitForSlotEvent)(CK_FLAGS flags, CK_SLOT_ID_PTR pSlot, CK_VOID_PTR pReserved)
 {
-	return CKR_FUNCTION_NOT_SUPPORTED;
+	return Go_WaitForSlotEvent(flags, pSlot, pReserved);
 }

--- a/pkcs11mod.go
+++ b/pkcs11mod.go
@@ -77,8 +77,8 @@ func Go_Finalize() C.CK_RV {
 
 //export Go_GetInfo
 func Go_GetInfo(p C.ckInfoPtr) C.CK_RV {
-	if (p == nil) {
-		return C.CKR_ARGUMENTS_BAD;
+	if p == nil {
+		return C.CKR_ARGUMENTS_BAD
 	}
 
 	info, err := backend.GetInfo()
@@ -117,13 +117,13 @@ func Go_GetInfo(p C.ckInfoPtr) C.CK_RV {
 		p.libraryDescription[i] = C.CK_UTF8CHAR(ch)
 	}
 
-	return fromError(err)
+	return fromError(nil)
 }
 
 //export Go_GetSlotList
 func Go_GetSlotList(tokenPresent C.CK_BBOOL, pSlotList C.CK_SLOT_ID_PTR, pulCount C.CK_ULONG_PTR) C.CK_RV {
-	if (pulCount == nil) {
-		return C.CKR_ARGUMENTS_BAD;
+	if pulCount == nil {
+		return C.CKR_ARGUMENTS_BAD
 	}
 
 	goTokenPresent := fromCBBool(tokenPresent)
@@ -151,13 +151,13 @@ func Go_GetSlotList(tokenPresent C.CK_BBOOL, pSlotList C.CK_SLOT_ID_PTR, pulCoun
 		fromList(slotList, C.CK_ULONG_PTR(pSlotList), goCount)
 	}
 
-	return fromError(err)
+	return fromError(nil)
 }
 
 //export Go_GetSlotInfo
 func Go_GetSlotInfo(slotID C.CK_SLOT_ID, pInfo C.CK_SLOT_INFO_PTR) C.CK_RV {
-	if (pInfo == nil) {
-		return C.CKR_ARGUMENTS_BAD;
+	if pInfo == nil {
+		return C.CKR_ARGUMENTS_BAD
 	}
 
 	goSlotID := uint(slotID)
@@ -203,13 +203,13 @@ func Go_GetSlotInfo(slotID C.CK_SLOT_ID, pInfo C.CK_SLOT_INFO_PTR) C.CK_RV {
 		pInfo.manufacturerID[i] = C.CK_UTF8CHAR(ch)
 	}
 
-	return fromError(err)
+	return fromError(nil)
 }
 
 //export Go_GetTokenInfo
 func Go_GetTokenInfo(slotID C.CK_SLOT_ID, pInfo C.CK_TOKEN_INFO_PTR) C.CK_RV {
-	if (pInfo == nil) {
-		return C.CKR_ARGUMENTS_BAD;
+	if pInfo == nil {
+		return C.CKR_ARGUMENTS_BAD
 	}
 
 	goSlotID := uint(slotID)
@@ -308,8 +308,8 @@ func Go_GetTokenInfo(slotID C.CK_SLOT_ID, pInfo C.CK_TOKEN_INFO_PTR) C.CK_RV {
 
 //export Go_GetMechanismList
 func Go_GetMechanismList(slotID C.CK_SLOT_ID, pMechanismList C.CK_MECHANISM_TYPE_PTR, pulCount C.CK_ULONG_PTR) C.CK_RV {
-	if (pulCount == nil) {
-		return C.CKR_ARGUMENTS_BAD;
+	if pulCount == nil {
+		return C.CKR_ARGUMENTS_BAD
 	}
 
 	goSlotID := uint(slotID)
@@ -337,13 +337,66 @@ func Go_GetMechanismList(slotID C.CK_SLOT_ID, pMechanismList C.CK_MECHANISM_TYPE
 		fromMechanismList(mechanismList, C.CK_ULONG_PTR(pMechanismList), goCount)
 	}
 
+	return fromError(nil)
+}
+
+//export Go_GetMechanismInfo
+func Go_GetMechanismInfo(slotID C.CK_SLOT_ID, mechType C.CK_MECHANISM_TYPE, pInfo C.CK_MECHANISM_INFO_PTR) C.CK_RV {
+	if pInfo == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSlotID := uint(slotID)
+	goMechType := uint(mechType)
+
+	m := []*pkcs11.Mechanism{
+		&pkcs11.Mechanism{
+			Mechanism: goMechType,
+		},
+	}
+
+	mi, err := backend.GetMechanismInfo(goSlotID, m)
+	if err != nil {
+		return fromError(err)
+	}
+
+	pInfo.ulMinKeySize = C.CK_ULONG(mi.MinKeySize)
+	pInfo.ulMaxKeySize = C.CK_ULONG(mi.MaxKeySize)
+	pInfo.flags = C.CK_FLAGS(mi.Flags)
+	return fromError(nil)
+}
+
+//export Go_InitPIN
+func Go_InitPIN(sessionHandle C.CK_SESSION_HANDLE, pPin C.CK_UTF8CHAR_PTR, ulPinLen C.CK_ULONG) C.CK_RV {
+	if pPin == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goPin := string((*[1 << 30]byte)(unsafe.Pointer(pPin))[:ulPinLen:ulPinLen])
+
+	err := backend.InitPIN(goSessionHandle, goPin)
+	return fromError(err)
+}
+
+//export Go_SetPIN
+func Go_SetPIN(sessionHandle C.CK_SESSION_HANDLE, pOldPin C.CK_UTF8CHAR_PTR, ulOldLen C.CK_ULONG, pNewPin C.CK_UTF8CHAR_PTR, ulNewLen C.CK_ULONG) C.CK_RV {
+	if pOldPin == nil || pNewPin == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goOldPin := string(C.GoBytes(unsafe.Pointer(pOldPin), C.int(ulOldLen)))
+	goNewPin := string(C.GoBytes(unsafe.Pointer(pNewPin), C.int(ulNewLen)))
+
+	err := backend.SetPIN(goSessionHandle, goOldPin, goNewPin)
 	return fromError(err)
 }
 
 //export Go_OpenSession
 func Go_OpenSession(slotID C.CK_SLOT_ID, flags C.CK_FLAGS, phSession C.CK_SESSION_HANDLE_PTR) C.CK_RV {
-	if (phSession == nil) {
-		return C.CKR_ARGUMENTS_BAD;
+	if phSession == nil {
+		return C.CKR_ARGUMENTS_BAD
 	}
 
 	goSlotID := uint(slotID)
@@ -355,8 +408,7 @@ func Go_OpenSession(slotID C.CK_SLOT_ID, flags C.CK_FLAGS, phSession C.CK_SESSIO
 	}
 
 	*phSession = C.CK_SESSION_HANDLE(sessionHandle)
-
-	return fromError(err)
+	return fromError(nil)
 }
 
 //export Go_CloseSession
@@ -367,10 +419,75 @@ func Go_CloseSession(sessionHandle C.CK_SESSION_HANDLE) C.CK_RV {
 	return fromError(err)
 }
 
+//export Go_CloseAllSessions
+func Go_CloseAllSessions(slotID C.CK_SLOT_ID) C.CK_RV {
+	goSlotID := uint(slotID)
+
+	err := backend.CloseAllSessions(goSlotID)
+	return fromError(err)
+}
+
+//export Go_GetOperationState
+func Go_GetOperationState(sessionHandle C.CK_SESSION_HANDLE, pOperationState C.CK_BYTE_PTR, pulOperationStateLen C.CK_ULONG_PTR) C.CK_RV {
+	if pOperationState == nil || pulOperationStateLen == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goOperationState := (*[1 << 30]byte)(unsafe.Pointer(pOperationState))[:*pulOperationStateLen:*pulOperationStateLen]
+
+	result, err := backend.GetOperationState(goSessionHandle)
+	if err != nil {
+		return fromError(err)
+	}
+
+	if int(*pulOperationStateLen) < len(result) {
+		return C.CKR_BUFFER_TOO_SMALL
+	}
+
+	copy(goOperationState, result)
+	*pulOperationStateLen = C.CK_ULONG(len(result))
+	return fromError(nil)
+}
+
+//export Go_SetOperationState
+func Go_SetOperationState(sessionHandle C.CK_SESSION_HANDLE, pOperationState C.CK_BYTE_PTR, ulOperationStateLen C.CK_LONG, hEncryptionKey C.CK_OBJECT_HANDLE, hAuthenticationKey C.CK_OBJECT_HANDLE) C.CK_RV {
+	if pOperationState == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goEncryptionKey := pkcs11.ObjectHandle(hEncryptionKey)
+	goAuthenticationKey := pkcs11.ObjectHandle(hAuthenticationKey)
+	goOperationState := C.GoBytes(unsafe.Pointer(pOperationState), C.int(ulOperationStateLen))
+
+	err := backend.SetOperationState(goSessionHandle, goOperationState, goEncryptionKey, goAuthenticationKey)
+	return fromError(err)
+}
+
+//export Go_GetSessionInfo
+func Go_GetSessionInfo(sessionHandle C.CK_SESSION_HANDLE, pInfo C.CK_SESSION_INFO_PTR) C.CK_RV {
+	if pInfo == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+
+	info, err := backend.GetSessionInfo(goSessionHandle)
+	if err != nil {
+		return fromError(err)
+	}
+
+	pInfo.slotID = C.CK_SLOT_ID(info.SlotID)
+	pInfo.state = C.CK_STATE(info.State)
+	pInfo.flags = C.CK_FLAGS(info.Flags)
+	pInfo.ulDeviceError = C.CK_ULONG(info.DeviceError)
+	return fromError(nil)
+}
+
 //export Go_Login
 func Go_Login(sessionHandle C.CK_SESSION_HANDLE, userType C.CK_USER_TYPE, pPin C.CK_UTF8CHAR_PTR, ulPinLen C.CK_ULONG) C.CK_RV {
-	if (pPin == nil) {
-		return C.CKR_ARGUMENTS_BAD;
+	if pPin == nil {
+		return C.CKR_ARGUMENTS_BAD
 	}
 
 	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
@@ -389,10 +506,56 @@ func Go_Logout(sessionHandle C.CK_SESSION_HANDLE) C.CK_RV {
 	return fromError(err)
 }
 
+//export Go_CreateObject
+func Go_CreateObject(sessionHandle C.CK_SESSION_HANDLE, pTemplate C.CK_ATTRIBUTE_PTR, ulCount C.CK_ULONG, phObject C.CK_OBJECT_HANDLE_PTR) C.CK_RV {
+	if pTemplate == nil && ulCount > 0 || phObject == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goTemplate := toTemplate(pTemplate, ulCount)
+
+	goHandle, err := backend.CreateObject(goSessionHandle, goTemplate)
+	if err != nil {
+		return fromError(err)
+	}
+
+	*phObject = C.CK_OBJECT_HANDLE(goHandle)
+	return fromError(nil)
+}
+
+//export Go_CopyObject
+func Go_CopyObject(sessionHandle C.CK_SESSION_HANDLE, hObject C.CK_OBJECT_HANDLE, pTemplate C.CK_ATTRIBUTE_PTR, ulCount C.CK_ULONG, phNewObject C.CK_OBJECT_HANDLE_PTR) C.CK_RV {
+	if pTemplate == nil && ulCount > 0 || phNewObject == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goTemplate := toTemplate(pTemplate, ulCount)
+	goObjectHandle := pkcs11.ObjectHandle(hObject)
+
+	goHandle, err := backend.CopyObject(goSessionHandle, goObjectHandle, goTemplate)
+	if err != nil {
+		return fromError(err)
+	}
+
+	*phNewObject = C.CK_OBJECT_HANDLE(goHandle)
+	return fromError(nil)
+}
+
+//export Go_DestroyObject
+func Go_DestroyObject(sessionHandle C.CK_SESSION_HANDLE, hObject C.CK_OBJECT_HANDLE) C.CK_RV {
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goObjectHandle := pkcs11.ObjectHandle(hObject)
+
+	err := backend.DestroyObject(goSessionHandle, goObjectHandle)
+	return fromError(err)
+}
+
 //export Go_GetObjectSize
 func Go_GetObjectSize(sessionHandle C.CK_SESSION_HANDLE, objectHandle C.CK_OBJECT_HANDLE, pulSize C.CK_ULONG_PTR) C.CK_RV {
-	if (pulSize == nil) {
-		return C.CKR_ARGUMENTS_BAD;
+	if pulSize == nil {
+		return C.CKR_ARGUMENTS_BAD
 	}
 
 	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
@@ -404,14 +567,13 @@ func Go_GetObjectSize(sessionHandle C.CK_SESSION_HANDLE, objectHandle C.CK_OBJEC
 	}
 
 	*pulSize = C.CK_ULONG(goSize)
-
-	return fromError(err)
+	return fromError(nil)
 }
 
 //export Go_GetAttributeValue
 func Go_GetAttributeValue(sessionHandle C.CK_SESSION_HANDLE, objectHandle C.CK_OBJECT_HANDLE, pTemplate C.CK_ATTRIBUTE_PTR, ulCount C.CK_ULONG) C.CK_RV {
-	if (pTemplate == nil && ulCount > 0) {
-		return C.CKR_ARGUMENTS_BAD;
+	if pTemplate == nil && ulCount > 0 {
+		return C.CKR_ARGUMENTS_BAD
 	}
 
 	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
@@ -427,10 +589,24 @@ func Go_GetAttributeValue(sessionHandle C.CK_SESSION_HANDLE, objectHandle C.CK_O
 	return fromError(err)
 }
 
+//export Go_SetAttributeValue
+func Go_SetAttributeValue(sessionHandle C.CK_SESSION_HANDLE, hObject C.CK_OBJECT_HANDLE, pTemplate C.CK_ATTRIBUTE_PTR, ulCount C.CK_ULONG) C.CK_RV {
+	if pTemplate == nil && ulCount > 0 {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goObjectHandle := pkcs11.ObjectHandle(hObject)
+	goTemplate := toTemplate(pTemplate, ulCount)
+
+	err := backend.SetAttributeValue(goSessionHandle, goObjectHandle, goTemplate)
+	return fromError(err)
+}
+
 //export Go_FindObjectsInit
 func Go_FindObjectsInit(sessionHandle C.CK_SESSION_HANDLE, pTemplate C.CK_ATTRIBUTE_PTR, ulCount C.CK_ULONG) C.CK_RV {
-	if (pTemplate == nil && ulCount > 0) {
-		return C.CKR_ARGUMENTS_BAD;
+	if pTemplate == nil && ulCount > 0 {
+		return C.CKR_ARGUMENTS_BAD
 	}
 
 	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
@@ -445,11 +621,8 @@ func Go_FindObjects(sessionHandle C.CK_SESSION_HANDLE, phObject C.CK_OBJECT_HAND
 	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
 	goMax := int(ulMaxObjectCount)
 
-	if (phObject == nil && goMax > 0) {
-		return C.CKR_ARGUMENTS_BAD;
-	}
-	if (pulObjectCount == nil) {
-		return C.CKR_ARGUMENTS_BAD;
+	if (phObject == nil && goMax > 0) || pulObjectCount == nil {
+		return C.CKR_ARGUMENTS_BAD
 	}
 
 	objectHandles, _, err := backend.FindObjects(goSessionHandle, goMax)
@@ -460,8 +633,7 @@ func Go_FindObjects(sessionHandle C.CK_SESSION_HANDLE, phObject C.CK_OBJECT_HAND
 	goCount := uint(len(objectHandles))
 	*pulObjectCount = C.CK_ULONG(goCount)
 	fromObjectHandleList(objectHandles, C.CK_ULONG_PTR(phObject), goCount)
-
-	return fromError(err)
+	return fromError(nil)
 }
 
 //export Go_FindObjectsFinal
@@ -470,4 +642,711 @@ func Go_FindObjectsFinal(sessionHandle C.CK_SESSION_HANDLE) C.CK_RV {
 
 	err := backend.FindObjectsFinal(goSessionHandle)
 	return fromError(err)
+}
+
+//export Go_EncryptInit
+func Go_EncryptInit(sessionHandle C.CK_SESSION_HANDLE, pMechanism C.CK_MECHANISM_PTR, hKey C.CK_OBJECT_HANDLE) C.CK_RV {
+	if pMechanism == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goObjectHandle := pkcs11.ObjectHandle(hKey)
+	goMechanism := toMechanism(pMechanism)
+
+	err := backend.EncryptInit(goSessionHandle, []*pkcs11.Mechanism{goMechanism}, goObjectHandle)
+	return fromError(err)
+}
+
+//export Go_Encrypt
+func Go_Encrypt(sessionHandle C.CK_SESSION_HANDLE, pData C.CK_BYTE_PTR, ulDataLen C.CK_ULONG, pEncryptedData C.CK_BYTE_PTR, pulEncryptedDataLen C.CK_ULONG_PTR) C.CK_RV {
+	if pData == nil || pulEncryptedDataLen == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goData := C.GoBytes(unsafe.Pointer(pData), C.int(ulDataLen))
+
+	goEncryptedData := (*[1 << 30]byte)(unsafe.Pointer(pEncryptedData))[:*pulEncryptedDataLen:*pulEncryptedDataLen]
+
+	encryptedData, err := backend.Encrypt(goSessionHandle, goData)
+	if err != nil {
+		return fromError(err)
+	}
+
+	if int(*pulEncryptedDataLen) < len(encryptedData) {
+		return C.CKR_BUFFER_TOO_SMALL
+	}
+
+	copy(goEncryptedData, encryptedData)
+	*pulEncryptedDataLen = C.CK_ULONG(len(encryptedData))
+	return fromError(nil)
+}
+
+//export Go_EncryptUpdate
+func Go_EncryptUpdate(sessionHandle C.CK_SESSION_HANDLE, pPart C.CK_BYTE_PTR, ulPartLen C.CK_ULONG, pEncryptedPart C.CK_BYTE_PTR, pulEncryptedPartLen C.CK_ULONG_PTR) C.CK_RV {
+	if pPart == nil || pEncryptedPart == nil || pulEncryptedPartLen == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goData := C.GoBytes(unsafe.Pointer(pPart), C.int(ulPartLen))
+	goEncryptedPart := (*[1 << 30]byte)(unsafe.Pointer(pEncryptedPart))[:*pulEncryptedPartLen:*pulEncryptedPartLen]
+
+	encryptedPart, err := backend.Encrypt(goSessionHandle, goData)
+	if err != nil {
+		return fromError(err)
+	}
+
+	if int(*pulEncryptedPartLen) < len(encryptedPart) {
+		return C.CKR_BUFFER_TOO_SMALL
+	}
+
+	copy(goEncryptedPart, encryptedPart)
+	*pulEncryptedPartLen = C.CK_ULONG(len(encryptedPart))
+	return fromError(nil)
+}
+
+//export Go_EncryptFinal
+func Go_EncryptFinal(sessionHandle C.CK_SESSION_HANDLE, pLastEncryptedPart C.CK_BYTE_PTR, pulLastEncryptedPartLen C.CK_ULONG_PTR) C.CK_RV {
+	if pLastEncryptedPart == nil || pulLastEncryptedPartLen == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goLastEncryptedPart := (*[1 << 30]byte)(unsafe.Pointer(pLastEncryptedPart))[:*pulLastEncryptedPartLen:*pulLastEncryptedPartLen]
+
+	lastEncryptedPart, err := backend.EncryptFinal(goSessionHandle)
+	if err != nil {
+		return fromError(err)
+	}
+
+	if int(*pulLastEncryptedPartLen) < len(lastEncryptedPart) {
+		return C.CKR_BUFFER_TOO_SMALL
+	}
+
+	copy(goLastEncryptedPart, lastEncryptedPart)
+	*pulLastEncryptedPartLen = C.CK_ULONG(len(lastEncryptedPart))
+	return fromError(nil)
+}
+
+//export Go_DecryptInit
+func Go_DecryptInit(sessionHandle C.CK_SESSION_HANDLE, pMechanism C.CK_MECHANISM_PTR, hKey C.CK_OBJECT_HANDLE) C.CK_RV {
+	if pMechanism == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goObjectHandle := pkcs11.ObjectHandle(hKey)
+	goMechanism := toMechanism(pMechanism)
+
+	err := backend.DecryptInit(goSessionHandle, []*pkcs11.Mechanism{goMechanism}, goObjectHandle)
+	return fromError(err)
+}
+
+//export Go_Decrypt
+func Go_Decrypt(sessionHandle C.CK_SESSION_HANDLE, pEncryptedData C.CK_BYTE_PTR, ulEncryptedDataLen C.CK_ULONG, pData C.CK_BYTE_PTR, pulDataLen C.CK_ULONG_PTR) C.CK_RV {
+	if pEncryptedData == nil || pulDataLen == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goEncryptedData := C.GoBytes(unsafe.Pointer(pEncryptedData), C.int(ulEncryptedDataLen))
+
+	goData := (*[1 << 30]byte)(unsafe.Pointer(pData))[:*pulDataLen:*pulDataLen]
+
+	data, err := backend.Decrypt(goSessionHandle, goEncryptedData)
+	if err != nil {
+		return fromError(err)
+	}
+
+	if int(*pulDataLen) < len(data) {
+		return C.CKR_BUFFER_TOO_SMALL
+	}
+
+	copy(goData, data)
+	*pulDataLen = C.CK_ULONG(len(data))
+	return fromError(nil)
+}
+
+//export Go_DecryptUpdate
+func Go_DecryptUpdate(sessionHandle C.CK_SESSION_HANDLE, pEncryptedPart C.CK_BYTE_PTR, ulEncryptedPartLen C.CK_ULONG, pPart C.CK_BYTE_PTR, pulPartLen C.CK_ULONG_PTR) C.CK_RV {
+	if pEncryptedPart == nil || pPart == nil || pulPartLen == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goData := C.GoBytes(unsafe.Pointer(pPart), C.int(ulEncryptedPartLen))
+	goPart := (*[1 << 30]byte)(unsafe.Pointer(pPart))[:*pulPartLen:*pulPartLen]
+
+	decryptedPart, err := backend.Decrypt(goSessionHandle, goData)
+	if err != nil {
+		return fromError(err)
+	}
+
+	if int(*pulPartLen) < len(decryptedPart) {
+		return C.CKR_BUFFER_TOO_SMALL
+	}
+
+	copy(goPart, decryptedPart)
+	*pulPartLen = C.CK_ULONG(len(decryptedPart))
+	return fromError(nil)
+}
+
+//export Go_DecryptFinal
+func Go_DecryptFinal(sessionHandle C.CK_SESSION_HANDLE, pLastPart C.CK_BYTE_PTR, pulLastPartLen C.CK_ULONG_PTR) C.CK_RV {
+	if pLastPart == nil || pulLastPartLen == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goLastPart := (*[1 << 30]byte)(unsafe.Pointer(pLastPart))[:*pulLastPartLen:*pulLastPartLen]
+
+	lastDataPart, err := backend.DecryptFinal(goSessionHandle)
+	if err != nil {
+		return fromError(err)
+	}
+
+	if int(*pulLastPartLen) < len(lastDataPart) {
+		return C.CKR_BUFFER_TOO_SMALL
+	}
+
+	copy(goLastPart, lastDataPart)
+	*pulLastPartLen = C.CK_ULONG(len(lastDataPart))
+	return fromError(err)
+}
+
+//export Go_DigestInit
+func Go_DigestInit(sessionHandle C.CK_SESSION_HANDLE, pMechanism C.CK_MECHANISM_PTR) C.CK_RV {
+	if pMechanism == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goMechanism := toMechanism(pMechanism)
+	err := backend.DigestInit(goSessionHandle, []*pkcs11.Mechanism{goMechanism})
+	return fromError(err)
+}
+
+//export Go_Digest
+func Go_Digest(sessionHandle C.CK_SESSION_HANDLE, pData C.CK_BYTE_PTR, ulDataLen C.CK_ULONG, pDigest C.CK_BYTE_PTR, pulDigestLen C.CK_ULONG_PTR) C.CK_RV {
+	if pData == nil || pulDigestLen == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goData := C.GoBytes(unsafe.Pointer(pData), C.int(ulDataLen))
+
+	goDigest := (*[1 << 30]byte)(unsafe.Pointer(pDigest))[:*pulDigestLen:*pulDigestLen]
+
+	digest, err := backend.Digest(goSessionHandle, goData)
+	if err != nil {
+		return fromError(err)
+	}
+
+	if int(*pulDigestLen) < len(digest) {
+		return C.CKR_BUFFER_TOO_SMALL
+	}
+
+	copy(goDigest, digest)
+	*pulDigestLen = C.CK_ULONG(len(digest))
+	return fromError(nil)
+}
+
+//export Go_DigestUpdate
+func Go_DigestUpdate(sessionHandle C.CK_SESSION_HANDLE, pPart C.CK_BYTE_PTR, ulPartLen C.CK_ULONG) C.CK_RV {
+	if pPart == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goPart := C.GoBytes(unsafe.Pointer(pPart), C.int(ulPartLen))
+
+	err := backend.DigestUpdate(goSessionHandle, goPart)
+	return fromError(err)
+}
+
+//export Go_DigestKey
+func Go_DigestKey(sessionHandle C.CK_SESSION_HANDLE, hKey C.CK_OBJECT_HANDLE) C.CK_RV {
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goKeyHandle := pkcs11.ObjectHandle(hKey)
+
+	err := backend.DigestKey(goSessionHandle, goKeyHandle)
+	return fromError(err)
+}
+
+//export Go_DigestFinal
+func Go_DigestFinal(sessionHandle C.CK_SESSION_HANDLE, pDigest C.CK_BYTE_PTR, pulDigestLen C.CK_ULONG_PTR) C.CK_RV {
+	if pDigest == nil || pulDigestLen == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goDigest := (*[1 << 30]byte)(unsafe.Pointer(pDigest))[:*pulDigestLen:*pulDigestLen]
+
+	digest, err := backend.DigestFinal(goSessionHandle)
+	if err != nil {
+		return fromError(err)
+	}
+
+	if int(*pulDigestLen) < len(digest) {
+		return C.CKR_BUFFER_TOO_SMALL
+	}
+
+	copy(goDigest, digest)
+	*pulDigestLen = C.CK_ULONG(len(digest))
+	return fromError(nil)
+}
+
+//export Go_SignInit
+func Go_SignInit(sessionHandle C.CK_SESSION_HANDLE, pMechanism C.CK_MECHANISM_PTR, hKey C.CK_OBJECT_HANDLE) C.CK_RV {
+	if pMechanism == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goObjectHandle := pkcs11.ObjectHandle(hKey)
+	goMechanism := toMechanism(pMechanism)
+
+	err := backend.SignInit(goSessionHandle, []*pkcs11.Mechanism{goMechanism}, goObjectHandle)
+	return fromError(err)
+}
+
+//export Go_Sign
+func Go_Sign(sessionHandle C.CK_SESSION_HANDLE, pData C.CK_BYTE_PTR, ulDataLen C.CK_ULONG, pSignature C.CK_BYTE_PTR, pulSignatureLen C.CK_ULONG_PTR) C.CK_RV {
+	if pData == nil || pulSignatureLen == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goData := C.GoBytes(unsafe.Pointer(pData), C.int(ulDataLen))
+
+	goSignature := (*[1 << 30]byte)(unsafe.Pointer(pSignature))[:*pulSignatureLen:*pulSignatureLen]
+
+	signature, err := backend.Sign(goSessionHandle, goData)
+	if err != nil {
+		return fromError(err)
+	}
+
+	if int(*pulSignatureLen) < len(signature) {
+		return C.CKR_BUFFER_TOO_SMALL
+	}
+
+	copy(goSignature, signature)
+	*pulSignatureLen = C.CK_ULONG(len(signature))
+	return fromError(nil)
+}
+
+//export Go_SignUpdate
+func Go_SignUpdate(sessionHandle C.CK_SESSION_HANDLE, pPart C.CK_BYTE_PTR, ulPartLen C.CK_ULONG) C.CK_RV {
+	if pPart == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goPart := C.GoBytes(unsafe.Pointer(pPart), C.int(ulPartLen))
+
+	err := backend.SignUpdate(goSessionHandle, goPart)
+	return fromError(err)
+}
+
+//export Go_SignFinal
+func Go_SignFinal(sessionHandle C.CK_SESSION_HANDLE, pSignature C.CK_BYTE_PTR, pulSignatureLen C.CK_ULONG_PTR) C.CK_RV {
+	if pSignature == nil || pulSignatureLen == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goSignature := (*[1 << 30]byte)(unsafe.Pointer(pSignature))[:*pulSignatureLen:*pulSignatureLen]
+
+	signature, err := backend.SignFinal(goSessionHandle)
+	if err != nil {
+		return fromError(err)
+	}
+
+	if int(*pulSignatureLen) < len(signature) {
+		return C.CKR_BUFFER_TOO_SMALL
+	}
+
+	copy(goSignature, signature)
+	*pulSignatureLen = C.CK_ULONG(len(signature))
+	return fromError(nil)
+}
+
+//export Go_SignRecoverInit
+func Go_SignRecoverInit(sessionHandle C.CK_SESSION_HANDLE, pMechanism C.CK_MECHANISM_PTR, hKey C.CK_OBJECT_HANDLE) C.CK_RV {
+	if pMechanism == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goObjectHandle := pkcs11.ObjectHandle(hKey)
+	goMechanism := toMechanism(pMechanism)
+
+	err := backend.SignRecoverInit(goSessionHandle, []*pkcs11.Mechanism{goMechanism}, goObjectHandle)
+	return fromError(err)
+}
+
+//export Go_SignRecover
+func Go_SignRecover(sessionHandle C.CK_SESSION_HANDLE, pData C.CK_BYTE_PTR, ulDataLen C.CK_ULONG, pSignature C.CK_BYTE_PTR, pulSignatureLen C.CK_ULONG_PTR) C.CK_RV {
+	if pData == nil || pSignature == nil || pulSignatureLen == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goData := C.GoBytes(unsafe.Pointer(pData), C.int(ulDataLen))
+	goSignature := (*[1 << 30]byte)(unsafe.Pointer(pSignature))[:*pulSignatureLen:*pulSignatureLen]
+
+	signature, err := backend.SignRecover(goSessionHandle, goData)
+	if err != nil {
+		return fromError(err)
+	}
+
+	if int(*pulSignatureLen) < len(signature) {
+		return C.CKR_BUFFER_TOO_SMALL
+	}
+
+	copy(goSignature, signature)
+	*pulSignatureLen = C.CK_ULONG(len(signature))
+	return fromError(nil)
+}
+
+//export Go_VerifyInit
+func Go_VerifyInit(sessionHandle C.CK_SESSION_HANDLE, pMechanism C.CK_MECHANISM_PTR, hKey C.CK_OBJECT_HANDLE) C.CK_RV {
+	if pMechanism == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goObjectHandle := pkcs11.ObjectHandle(hKey)
+	goMechanism := toMechanism(pMechanism)
+
+	err := backend.VerifyInit(goSessionHandle, []*pkcs11.Mechanism{goMechanism}, goObjectHandle)
+	return fromError(err)
+}
+
+//export Go_Verify
+func Go_Verify(sessionHandle C.CK_SESSION_HANDLE, pData C.CK_BYTE_PTR, ulDataLen C.CK_ULONG, pSignature C.CK_BYTE_PTR, ulSignatureLen C.CK_ULONG) C.CK_RV {
+	if pData == nil || pSignature == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goData := C.GoBytes(unsafe.Pointer(pData), C.int(ulDataLen))
+	goSignature := C.GoBytes(unsafe.Pointer(pSignature), C.int(ulSignatureLen))
+
+	err := backend.Verify(goSessionHandle, goData, goSignature)
+	return fromError(err)
+}
+
+//export Go_VerifyUpdate
+func Go_VerifyUpdate(sessionHandle C.CK_SESSION_HANDLE, pPart C.CK_BYTE_PTR, ulPartLen C.CK_ULONG) C.CK_RV {
+	if pPart == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goPart := C.GoBytes(unsafe.Pointer(pPart), C.int(ulPartLen))
+
+	err := backend.VerifyUpdate(goSessionHandle, goPart)
+	return fromError(err)
+}
+
+//export Go_VerifyFinal
+func Go_VerifyFinal(sessionHandle C.CK_SESSION_HANDLE, pSignature C.CK_BYTE_PTR, ulSignatureLen C.CK_ULONG) C.CK_RV {
+	if pSignature == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goSignature := C.GoBytes(unsafe.Pointer(pSignature), C.int(ulSignatureLen))
+
+	err := backend.VerifyFinal(goSessionHandle, goSignature)
+	return fromError(err)
+}
+
+//export Go_VerifyRecoverInit
+func Go_VerifyRecoverInit(sessionHandle C.CK_SESSION_HANDLE, pMechanism C.CK_MECHANISM_PTR, hKey C.CK_OBJECT_HANDLE) C.CK_RV {
+	if pMechanism == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goObjectHandle := pkcs11.ObjectHandle(hKey)
+	goMechanism := toMechanism(pMechanism)
+
+	err := backend.VerifyRecoverInit(goSessionHandle, []*pkcs11.Mechanism{goMechanism}, goObjectHandle)
+	return fromError(err)
+}
+
+//export Go_VerifyRecover
+func Go_VerifyRecover(sessionHandle C.CK_SESSION_HANDLE, pSignature C.CK_BYTE_PTR, ulSignatureLen C.CK_ULONG, pData C.CK_BYTE_PTR, pulDataLen C.CK_ULONG_PTR) C.CK_RV {
+	if pData == nil || pSignature == nil || pulDataLen == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goSignature := C.GoBytes(unsafe.Pointer(pSignature), C.int(ulSignatureLen))
+	goData := (*[1 << 30]byte)(unsafe.Pointer(pData))[:*pulDataLen:*pulDataLen]
+
+	data, err := backend.VerifyRecover(goSessionHandle, goSignature)
+	if err != nil {
+		return fromError(err)
+	}
+
+	if int(*pulDataLen) < len(data) {
+		return C.CKR_BUFFER_TOO_SMALL
+	}
+
+	copy(goData, data)
+	*pulDataLen = C.CK_ULONG(len(data))
+	return fromError(nil)
+}
+
+//export Go_DigestEncryptUpdate
+func Go_DigestEncryptUpdate(sessionHandle C.CK_SESSION_HANDLE, pPart C.CK_BYTE_PTR, ulPartLen C.CK_ULONG, pEncryptedPart C.CK_BYTE_PTR, pulEncryptedPartLen C.CK_ULONG_PTR) C.CK_RV {
+	if pPart == nil || pEncryptedPart == nil || pulEncryptedPartLen == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goPart := C.GoBytes(unsafe.Pointer(pPart), C.int(ulPartLen))
+	goEncryptedPart := (*[1 << 30]byte)(unsafe.Pointer(pEncryptedPart))[:*pulEncryptedPartLen:*pulEncryptedPartLen]
+
+	encryptedPart, err := backend.DigestEncryptUpdate(goSessionHandle, goPart)
+	if err != nil {
+		return fromError(err)
+	}
+
+	if int(*pulEncryptedPartLen) < len(encryptedPart) {
+		return C.CKR_BUFFER_TOO_SMALL
+	}
+
+	copy(goEncryptedPart, encryptedPart)
+	*pulEncryptedPartLen = C.CK_ULONG(len(encryptedPart))
+	return fromError(nil)
+}
+
+//export Go_DecryptDigestUpdate
+func Go_DecryptDigestUpdate(sessionHandle C.CK_SESSION_HANDLE, pEncryptedPart C.CK_BYTE_PTR, ulEncryptedPartLen C.CK_ULONG, pPart C.CK_BYTE_PTR, pulPartLen C.CK_ULONG_PTR) C.CK_RV {
+	if pPart == nil || pEncryptedPart == nil || pulPartLen == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goEncryptedPart := C.GoBytes(unsafe.Pointer(pEncryptedPart), C.int(ulEncryptedPartLen))
+	goPart := (*[1 << 30]byte)(unsafe.Pointer(pEncryptedPart))[:*pulPartLen:*pulPartLen]
+
+	part, err := backend.DecryptDigestUpdate(goSessionHandle, goEncryptedPart)
+	if err != nil {
+		return fromError(err)
+	}
+
+	if int(*pulPartLen) < len(part) {
+		return C.CKR_BUFFER_TOO_SMALL
+	}
+
+	copy(goPart, part)
+	*pulPartLen = C.CK_ULONG(len(part))
+	return fromError(nil)
+}
+
+//export Go_SignEncryptUpdate
+func Go_SignEncryptUpdate(sessionHandle C.CK_SESSION_HANDLE, pPart C.CK_BYTE_PTR, ulPartLen C.CK_ULONG, pEncryptedPart C.CK_BYTE_PTR, pulEncryptedPartLen C.CK_ULONG_PTR) C.CK_RV {
+	if pPart == nil || pEncryptedPart == nil || pulEncryptedPartLen == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goPart := C.GoBytes(unsafe.Pointer(pPart), C.int(ulPartLen))
+	goEncryptedPart := (*[1 << 30]byte)(unsafe.Pointer(pEncryptedPart))[:*pulEncryptedPartLen:*pulEncryptedPartLen]
+
+	encryptedPart, err := backend.SignEncryptUpdate(goSessionHandle, goPart)
+	if err != nil {
+		return fromError(err)
+	}
+
+	if int(*pulEncryptedPartLen) < len(encryptedPart) {
+		return C.CKR_BUFFER_TOO_SMALL
+	}
+
+	copy(goEncryptedPart, encryptedPart)
+	*pulEncryptedPartLen = C.CK_ULONG(len(encryptedPart))
+	return fromError(nil)
+}
+
+//export Go_DecryptVerifyUpdate
+func Go_DecryptVerifyUpdate(sessionHandle C.CK_SESSION_HANDLE, pEncryptedPart C.CK_BYTE_PTR, ulEncryptedPartLen C.CK_ULONG, pPart C.CK_BYTE_PTR, pulPartLen C.CK_ULONG_PTR) C.CK_RV {
+	if pPart == nil || pEncryptedPart == nil || pulPartLen == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goEncryptedPart := C.GoBytes(unsafe.Pointer(pEncryptedPart), C.int(ulEncryptedPartLen))
+	goPart := (*[1 << 30]byte)(unsafe.Pointer(pEncryptedPart))[:*pulPartLen:*pulPartLen]
+
+	part, err := backend.DecryptVerifyUpdate(goSessionHandle, goEncryptedPart)
+	if err != nil {
+		return fromError(err)
+	}
+
+	if int(*pulPartLen) < len(part) {
+		return C.CKR_BUFFER_TOO_SMALL
+	}
+
+	copy(goPart, part)
+	*pulPartLen = C.CK_ULONG(len(part))
+	return fromError(nil)
+}
+
+//export Go_GenerateKey
+func Go_GenerateKey(sessionHandle C.CK_SESSION_HANDLE, pMechanism C.CK_MECHANISM_PTR, pTemplate C.CK_ATTRIBUTE_PTR, ulCount C.CK_ULONG, phKey C.CK_OBJECT_HANDLE_PTR) C.CK_RV {
+	if pMechanism == nil || pTemplate == nil && ulCount > 0 || phKey == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goMechanism := toMechanism(pMechanism)
+	goTemplate := toTemplate(pTemplate, ulCount)
+
+	keyHandle, err := backend.GenerateKey(goSessionHandle, []*pkcs11.Mechanism{goMechanism}, goTemplate)
+	if err != nil {
+		return fromError(err)
+	}
+
+	*phKey = C.CK_OBJECT_HANDLE(keyHandle)
+	return fromError(nil)
+}
+
+//export Go_GenerateKeyPair
+func Go_GenerateKeyPair(sessionHandle C.CK_SESSION_HANDLE, pMechanism C.CK_MECHANISM_PTR, pPublicKeyTemplate C.CK_ATTRIBUTE_PTR, ulPublicKeyAttributeCount C.CK_ULONG, pPrivateKeyTemplate C.CK_ATTRIBUTE_PTR, ulPrivateKeyAttributeCount C.CK_ULONG, phPublicKey C.CK_OBJECT_HANDLE_PTR, phPrivateKey C.CK_OBJECT_HANDLE_PTR) C.CK_RV {
+	if pMechanism == nil || pPublicKeyTemplate == nil || pPrivateKeyTemplate == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goMechanism := toMechanism(pMechanism)
+	goPublicTemplate := toTemplate(pPublicKeyTemplate, ulPublicKeyAttributeCount)
+	goPrivateTemplate := toTemplate(pPrivateKeyTemplate, ulPrivateKeyAttributeCount)
+
+	pubKeyHandle, privKeyHandle, err := backend.GenerateKeyPair(goSessionHandle, []*pkcs11.Mechanism{goMechanism}, goPublicTemplate, goPrivateTemplate)
+	if err != nil {
+		return fromError(err)
+	}
+
+	*phPublicKey = C.CK_OBJECT_HANDLE(pubKeyHandle)
+	*phPrivateKey = C.CK_OBJECT_HANDLE(privKeyHandle)
+	return fromError(nil)
+}
+
+//export Go_WrapKey
+func Go_WrapKey(sessionHandle C.CK_SESSION_HANDLE, pMechanism C.CK_MECHANISM_PTR, hWrappingKey C.CK_OBJECT_HANDLE, hKey C.CK_OBJECT_HANDLE, pWrappedKey C.CK_BYTE_PTR, pulWrappedKeyLen C.CK_ULONG_PTR) C.CK_RV {
+	if pMechanism == nil || pWrappedKey == nil || pulWrappedKeyLen == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goMechanism := toMechanism(pMechanism)
+	goWrappingKey := pkcs11.ObjectHandle(hWrappingKey)
+	goKeyHandle := pkcs11.ObjectHandle(hKey)
+	goWrappedKey := (*[1 << 30]byte)(unsafe.Pointer(pWrappedKey))[:*pulWrappedKeyLen:*pulWrappedKeyLen]
+
+	wrappedKey, err := backend.WrapKey(goSessionHandle, []*pkcs11.Mechanism{goMechanism}, goWrappingKey, goKeyHandle)
+	if err != nil {
+		return fromError(nil)
+	}
+
+	if int(*pulWrappedKeyLen) < len(wrappedKey) {
+		return C.CKR_BUFFER_TOO_SMALL
+	}
+
+	copy(goWrappedKey, wrappedKey)
+	*pulWrappedKeyLen = C.CK_ULONG(len(wrappedKey))
+	return fromError(nil)
+}
+
+//export Go_UnwrapKey
+func Go_UnwrapKey(sessionHandle C.CK_SESSION_HANDLE, pMechanism C.CK_MECHANISM_PTR, hUnwrappingKey C.CK_OBJECT_HANDLE, pWrappedKey C.CK_BYTE_PTR, ulWrappedKeyLen C.CK_ULONG, pTemplate C.CK_ATTRIBUTE_PTR, ulAttributeCount C.CK_ULONG, phKey C.CK_OBJECT_HANDLE_PTR) C.CK_RV {
+	if pMechanism == nil || pWrappedKey == nil || phKey == nil || pTemplate == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goMechanism := toMechanism(pMechanism)
+	goTemplate := toTemplate(pTemplate, ulAttributeCount)
+	goUnwrappingKey := pkcs11.ObjectHandle(hUnwrappingKey)
+	goWrappedKey := C.GoBytes(unsafe.Pointer(pWrappedKey), C.int(ulWrappedKeyLen))
+
+	keyHandle, err := backend.UnwrapKey(goSessionHandle, []*pkcs11.Mechanism{goMechanism}, goUnwrappingKey, goWrappedKey, goTemplate)
+	if err != nil {
+		return fromError(nil)
+	}
+
+	*phKey = C.CK_OBJECT_HANDLE(keyHandle)
+	return fromError(nil)
+}
+
+//export Go_DeriveKey
+func Go_DeriveKey(sessionHandle C.CK_SESSION_HANDLE, pMechanism C.CK_MECHANISM_PTR, hBaseKey C.CK_OBJECT_HANDLE, pTemplate C.CK_ATTRIBUTE_PTR, ulAttributeCount C.CK_ULONG, phKey C.CK_OBJECT_HANDLE_PTR) C.CK_RV {
+	if pMechanism == nil || phKey == nil || pTemplate == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goMechanism := toMechanism(pMechanism)
+	goTemplate := toTemplate(pTemplate, ulAttributeCount)
+	goBaseKey := pkcs11.ObjectHandle(hBaseKey)
+
+	keyHandle, err := backend.DeriveKey(goSessionHandle, []*pkcs11.Mechanism{goMechanism}, goBaseKey, goTemplate)
+	if err != nil {
+		return fromError(nil)
+	}
+
+	*phKey = C.CK_OBJECT_HANDLE(keyHandle)
+	return fromError(nil)
+}
+
+//export Go_SeedRandom
+func Go_SeedRandom(sessionHandle C.CK_SESSION_HANDLE, pSeed C.CK_BYTE_PTR, ulSeedLen C.CK_ULONG) C.CK_RV {
+	if pSeed == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goSeed := C.GoBytes(unsafe.Pointer(pSeed), C.int(ulSeedLen))
+
+	err := backend.SeedRandom(goSessionHandle, goSeed)
+	return fromError(err)
+}
+
+//export Go_GenerateRandom
+func Go_GenerateRandom(sessionHandle C.CK_SESSION_HANDLE, pRandomData C.CK_BYTE_PTR, ulRandomLen C.CK_ULONG) C.CK_RV {
+	if pRandomData == nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+
+	goSessionHandle := pkcs11.SessionHandle(sessionHandle)
+	goRandomData := (*[1 << 30]byte)(unsafe.Pointer(pRandomData))[:ulRandomLen:ulRandomLen]
+	goRandomDataLen := int(ulRandomLen)
+
+	randomData, err := backend.GenerateRandom(goSessionHandle, goRandomDataLen)
+	if err != nil {
+		return fromError(err)
+	}
+
+	copy(goRandomData, randomData)
+	return fromError(nil)
+}
+
+//export Go_WaitForSlotEvent
+func Go_WaitForSlotEvent(flags C.CK_FLAGS, pSlot C.CK_SLOT_ID_PTR, pReserved C.CK_VOID_PTR) C.CK_RV {
+	if pSlot == nil || pReserved != nil {
+		return C.CKR_ARGUMENTS_BAD
+	}
+	goFlags := uint(flags)
+
+	slotEvent := <-backend.WaitForSlotEvent(goFlags)
+
+	*pSlot = C.CK_SLOT_ID(slotEvent.SlotID)
+	return fromError(nil)
 }


### PR DESCRIPTION
I noticed today that @bernard-wagner forked this repo last year and added a bunch of missing functions from the pkcs11 spec.  That's awesome!  I'd really like to merge these changes, assuming they pass a cursory review.  Bernard, can you comment on how well-tested these changes are?  Are there any known issues that should give us pause in merging them?  Is there a recommended way to test them?  (Maybe with SoftHSM?)  May I ask what you're using pkcs11mod for?  (Always curious to hear what my code is being used for in the wild.)