### PR TITLE
Fix object handle validation

### DIFF
--- a/p11mod/p11mod.go
+++ b/p11mod/p11mod.go
@@ -306,7 +306,7 @@ func (ll *llBackend) GetAttributeValue(sh pkcs11.SessionHandle, oh pkcs11.Object
 	// Handles are 1-indexed, while our slice is 0-indexed.
 	objectIndex := int(oh-1)
 
-	if objectIndex <= 0 || objectIndex >= len(session.objects) {
+	if objectIndex < 0 || objectIndex >= len(session.objects) {
 		log.Printf("p11mod GetAttributeValue: object index invalid: requested %d, object count %d\n", objectIndex, len(session.objects))
 		return []*pkcs11.Attribute{}, pkcs11.Error(pkcs11.CKR_OBJECT_HANDLE_INVALID)
 	}

--- a/p11mod/p11mod.go
+++ b/p11mod/p11mod.go
@@ -3,6 +3,7 @@
 package p11mod
 
 import (
+	"log"
 	"sync"
 
 	"github.com/miekg/pkcs11"
@@ -306,6 +307,7 @@ func (ll *llBackend) GetAttributeValue(sh pkcs11.SessionHandle, oh pkcs11.Object
 	objectIndex := int(oh-1)
 
 	if objectIndex <= 0 || objectIndex >= len(session.objects) {
+		log.Printf("p11mod GetAttributeValue: object index invalid: requested %d, object count %d\n", objectIndex, len(session.objects))
 		return []*pkcs11.Attribute{}, pkcs11.Error(pkcs11.CKR_OBJECT_HANDLE_INVALID)
 	}
 


### PR DESCRIPTION
Minimum slice index is 0, not 1.  Fixes Cirrus failure with gnutls-cli; kudos to GnuTLS for being stricter so I could notice the bug.