### PR TITLE
types.go: Decapitalize error strings

### DIFF
--- a/types.go
+++ b/types.go
@@ -168,7 +168,7 @@ func fromTemplate(template []*pkcs11.Attribute, clist C.CK_ATTRIBUTE_PTR) error 
 
 func BytesToBool(arg []byte) (bool, error) {
 	if len(arg) != 1 {
-		return false, fmt.Errorf("Invalid length: %d", len(arg))
+		return false, fmt.Errorf("invalid length: %d", len(arg))
 	}
 
 	return fromCBBool(*(*C.CK_BBOOL)(unsafe.Pointer(&arg[0]))), nil
@@ -177,7 +177,7 @@ func BytesToBool(arg []byte) (bool, error) {
 func BytesToULong(arg []byte) (uint, error) {
 	// TODO: use cgo to get the actual size of ULong instead of guessing "at least 4"
 	if len(arg) < 4 {
-		return 0, fmt.Errorf("Invalid length: %d", len(arg))
+		return 0, fmt.Errorf("invalid length: %d", len(arg))
 	}
 
 	return uint(*(*C.CK_ULONG)(unsafe.Pointer(&arg[0]))), nil


### PR DESCRIPTION
Reported by stylecheck