### PR TITLE
Test Firefox connections 5 times

### DIFF
--- a/testdata/try-firefox-connect.ps1
+++ b/testdata/try-firefox-connect.ps1
@@ -23,7 +23,7 @@ if ( "$Env:CI_DISABLE_E10S" -eq "1" ) {
 
 $result = "fail"
 
-foreach ($i in 1..3) {
+foreach ($i in 1..5) {
     # Nuke whatever cached state might exist...
     Remove-Item -Recurse -Force -ErrorAction SilentlyContinue "$Env:APPDATA/$Env:CI_APPDATA"
 


### PR DESCRIPTION
3 times doesn't seem to be enough sometimes.  This should cut down on spurious Cirrus failures.