### PR TITLE
add spec directory and string.go file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /moz/web-ext-artifacts/
 go.mod
 go.sum
+/spec
+strings.go


### PR DESCRIPTION
when building project on local machine, spec directory and string.go file are created and are unwanted on git.
so I thought if anyone builds it mistakenly again, the .gitignore might just do well to ignore them during deployment