### PR TITLE
Cirrus: Fix wget untrusted-root error message

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -591,7 +591,7 @@ task:
     - "Compile Go latest linux amd64"
 
 task:
-  name: "wget"
+  name: "wget fedora"
   container:
     image: fedora:latest
     cpu: 1

--- a/testdata/ci-wget-tests.bash
+++ b/testdata/ci-wget-tests.bash
@@ -11,17 +11,17 @@ echo "===== Default p11-kit-trust CKBI ====="
 testdata/try-wget-connect.bash www.namecoin.org success "" || testdata/dump-proxy-log-fail.bash
 testdata/assert-proxy-log.bash missing
 
-testdata/try-wget-connect.bash untrusted-root.badssl.com fail "doesn't have a known issuer" || testdata/dump-proxy-log-fail.bash
+testdata/try-wget-connect.bash untrusted-root.badssl.com fail "certificate issuer is unknown" || testdata/dump-proxy-log-fail.bash
 testdata/assert-proxy-log.bash missing
 
 echo "===== Deleted p11-kit-trust CKBI ====="
 
 mv /usr/lib64/pkcs11/p11-kit-trust.so /usr/lib64/pkcs11/p11-kit-trust.orig.so
 
-testdata/try-wget-connect.bash www.namecoin.org fail "doesn't have a known issuer" || testdata/dump-proxy-log-fail.bash
+testdata/try-wget-connect.bash www.namecoin.org fail "certificate issuer is unknown" || testdata/dump-proxy-log-fail.bash
 testdata/assert-proxy-log.bash missing
 
-testdata/try-wget-connect.bash untrusted-root.badssl.com fail "doesn't have a known issuer" || testdata/dump-proxy-log-fail.bash
+testdata/try-wget-connect.bash untrusted-root.badssl.com fail "certificate issuer is unknown" || testdata/dump-proxy-log-fail.bash
 testdata/assert-proxy-log.bash missing
 
 # TODO: No env var, missing default target
@@ -36,7 +36,7 @@ cp libpkcs11proxy.so /usr/lib64/pkcs11/p11-kit-trust.so
 testdata/try-wget-connect.bash www.namecoin.org success "" || testdata/dump-proxy-log-fail.bash
 testdata/assert-proxy-log.bash present
 
-testdata/try-wget-connect.bash untrusted-root.badssl.com fail "doesn't have a known issuer" || testdata/dump-proxy-log-fail.bash
+testdata/try-wget-connect.bash untrusted-root.badssl.com fail "certificate issuer is unknown" || testdata/dump-proxy-log-fail.bash
 testdata/assert-proxy-log.bash present
 
 echo "===== p11-kit-trust CKBI via p11proxy ====="
@@ -47,5 +47,5 @@ cp libp11proxy.so /usr/lib64/pkcs11/p11-kit-trust.so
 testdata/try-wget-connect.bash www.namecoin.org success "" || testdata/dump-proxy-log-fail.bash
 testdata/assert-proxy-log.bash present
 
-testdata/try-wget-connect.bash untrusted-root.badssl.com fail "doesn't have a known issuer" || testdata/dump-proxy-log-fail.bash
+testdata/try-wget-connect.bash untrusted-root.badssl.com fail "certificate issuer is unknown" || testdata/dump-proxy-log-fail.bash
 testdata/assert-proxy-log.bash present


### PR DESCRIPTION
wget seems to have changed their error message, which broke our tests.