### PR TITLE
Cirrus: Test on Debian oldstable+stable+testing+unstable

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -272,6 +272,17 @@ task:
         CI_MAIN_MODULE: /usr/lib64/pkcs11/p11-kit-trust.so
         CI_BAK_MODULE: /usr/lib64/pkcs11/p11-kit-trust.orig.so
     - container:
+        image: debian:oldstable
+        cpu: 1
+        memory: 1G
+      package_install_script:
+        - apt-get update
+        - apt-get install -y curl libnss3-tools
+      env:
+        CI_DISTRO: debian oldstable
+        CI_MAIN_MODULE: /usr/lib/x86_64-linux-gnu/nss/libnssckbi.so
+        CI_BAK_MODULE: /usr/lib/x86_64-linux-gnu/nss/libnssckbi.orig.so
+    - container:
         image: debian:latest
         cpu: 1
         memory: 1G
@@ -279,9 +290,31 @@ task:
         - apt-get update
         - apt-get install -y curl libnss3-tools
       env:
-        CI_DISTRO: debian
-        CI_MAIN_MODULE: /usr/lib/x86_64-linux-gnu/nss/libnssckbi.so
-        CI_BAK_MODULE: /usr/lib/x86_64-linux-gnu/nss/libnssckbi.orig.so
+        CI_DISTRO: debian stable
+        CI_MAIN_MODULE: /usr/lib/x86_64-linux-gnu/libnssckbi.so
+        CI_BAK_MODULE: /usr/lib/x86_64-linux-gnu/libnssckbi.orig.so
+    - container:
+        image: debian:testing
+        cpu: 1
+        memory: 1G
+      package_install_script:
+        - apt-get update
+        - apt-get install -y curl libnss3-tools
+      env:
+        CI_DISTRO: debian testing
+        CI_MAIN_MODULE: /usr/lib/x86_64-linux-gnu/libnssckbi.so
+        CI_BAK_MODULE: /usr/lib/x86_64-linux-gnu/libnssckbi.orig.so
+    - container:
+        image: debian:unstable
+        cpu: 1
+        memory: 1G
+      package_install_script:
+        - apt-get update
+        - apt-get install -y curl libnss3-tools
+      env:
+        CI_DISTRO: debian unstable
+        CI_MAIN_MODULE: /usr/lib/x86_64-linux-gnu/libnssckbi.so
+        CI_BAK_MODULE: /usr/lib/x86_64-linux-gnu/libnssckbi.orig.so
   install_script:
     - curl -o pkcs11mod.tar.gz https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/Compile%20Go%20latest%20linux%20amd64/binaries/dist/pkcs11mod.tar.gz
     - tar -xaf ./pkcs11mod.tar.gz
@@ -332,6 +365,18 @@ task:
         CI_MAIN_MODULE: /usr/lib64/pkcs11/p11-kit-trust.so
         CI_BAK_MODULE: /usr/lib64/pkcs11/p11-kit-trust.orig.so
     - container:
+        image: debian:oldstable
+        cpu: 1
+        memory: 1G
+      package_install_script:
+        - apt-get update
+        - apt-get install -y curl chromium
+        - ln -s -T /usr/bin/chromium /usr/bin/chromium-browser
+      env:
+        CI_DISTRO: debian oldstable
+        CI_MAIN_MODULE: /usr/lib/x86_64-linux-gnu/nss/libnssckbi.so
+        CI_BAK_MODULE: /usr/lib/x86_64-linux-gnu/nss/libnssckbi.orig.so
+    - container:
         image: debian:latest
         cpu: 1
         memory: 1G
@@ -340,9 +385,33 @@ task:
         - apt-get install -y curl chromium
         - ln -s -T /usr/bin/chromium /usr/bin/chromium-browser
       env:
-        CI_DISTRO: debian
-        CI_MAIN_MODULE: /usr/lib/x86_64-linux-gnu/nss/libnssckbi.so
-        CI_BAK_MODULE: /usr/lib/x86_64-linux-gnu/nss/libnssckbi.orig.so
+        CI_DISTRO: debian stable
+        CI_MAIN_MODULE: /usr/lib/x86_64-linux-gnu/libnssckbi.so
+        CI_BAK_MODULE: /usr/lib/x86_64-linux-gnu/libnssckbi.orig.so
+    - container:
+        image: debian:testing
+        cpu: 1
+        memory: 1G
+      package_install_script:
+        - apt-get update
+        - apt-get install -y curl chromium
+        - ln -s -T /usr/bin/chromium /usr/bin/chromium-browser
+      env:
+        CI_DISTRO: debian testing
+        CI_MAIN_MODULE: /usr/lib/x86_64-linux-gnu/libnssckbi.so
+        CI_BAK_MODULE: /usr/lib/x86_64-linux-gnu/libnssckbi.orig.so
+    - container:
+        image: debian:unstable
+        cpu: 1
+        memory: 1G
+      package_install_script:
+        - apt-get update
+        - apt-get install -y curl chromium
+        - ln -s -T /usr/bin/chromium /usr/bin/chromium-browser
+      env:
+        CI_DISTRO: debian unstable
+        CI_MAIN_MODULE: /usr/lib/x86_64-linux-gnu/libnssckbi.so
+        CI_BAK_MODULE: /usr/lib/x86_64-linux-gnu/libnssckbi.orig.so
   install_script:
     - curl -o pkcs11mod.tar.gz https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/Compile%20Go%20latest%20linux%20amd64/binaries/dist/pkcs11mod.tar.gz
     - tar -xaf ./pkcs11mod.tar.gz
@@ -389,6 +458,17 @@ task:
         CI_MAIN_MODULE: /usr/lib64/pkcs11/p11-kit-trust.so
         CI_BAK_MODULE: /usr/lib64/pkcs11/p11-kit-trust.orig.so
     - container:
+        image: debian:oldstable
+        cpu: 1
+        memory: 1G
+      package_install_script:
+        - apt-get update
+        - apt-get install -y curl firefox-esr
+      env:
+        CI_DISTRO: debian oldstable
+        CI_MAIN_MODULE: /usr/lib/firefox-esr/libnssckbi.so
+        CI_BAK_MODULE: /usr/lib/firefox-esr/libnssckbi.orig.so
+    - container:
         image: debian:latest
         cpu: 1
         memory: 1G
@@ -396,7 +476,29 @@ task:
         - apt-get update
         - apt-get install -y curl firefox-esr
       env:
-        CI_DISTRO: debian
+        CI_DISTRO: debian stable
+        CI_MAIN_MODULE: /usr/lib/firefox-esr/libnssckbi.so
+        CI_BAK_MODULE: /usr/lib/firefox-esr/libnssckbi.orig.so
+    - container:
+        image: debian:testing
+        cpu: 1
+        memory: 1G
+      package_install_script:
+        - apt-get update
+        - apt-get install -y curl firefox-esr
+      env:
+        CI_DISTRO: debian testing
+        CI_MAIN_MODULE: /usr/lib/firefox-esr/libnssckbi.so
+        CI_BAK_MODULE: /usr/lib/firefox-esr/libnssckbi.orig.so
+    - container:
+        image: debian:unstable
+        cpu: 1
+        memory: 1G
+      package_install_script:
+        - apt-get update
+        - apt-get install -y curl firefox-esr
+      env:
+        CI_DISTRO: debian unstable
         CI_MAIN_MODULE: /usr/lib/firefox-esr/libnssckbi.so
         CI_BAK_MODULE: /usr/lib/firefox-esr/libnssckbi.orig.so
   install_script:
@@ -571,6 +673,17 @@ task:
         CI_MAIN_MODULE: /usr/lib64/pkcs11/p11-kit-trust.so
         CI_BAK_MODULE: /usr/lib64/pkcs11/p11-kit-trust.orig.so
     - container:
+        image: debian:oldstable
+        cpu: 1
+        memory: 1G
+      package_install_script:
+        - apt-get update
+        - apt-get install -y curl libnss3-tools
+      env:
+        CI_DISTRO: debian oldstable
+        CI_MAIN_MODULE: /usr/lib/x86_64-linux-gnu/nss/libnssckbi.so
+        CI_BAK_MODULE: /usr/lib/x86_64-linux-gnu/nss/libnssckbi.orig.so
+    - container:
         image: debian:latest
         cpu: 1
         memory: 1G
@@ -578,9 +691,31 @@ task:
         - apt-get update
         - apt-get install -y curl libnss3-tools
       env:
-        CI_DISTRO: debian
-        CI_MAIN_MODULE: /usr/lib/x86_64-linux-gnu/nss/libnssckbi.so
-        CI_BAK_MODULE: /usr/lib/x86_64-linux-gnu/nss/libnssckbi.orig.so
+        CI_DISTRO: debian stable
+        CI_MAIN_MODULE: /usr/lib/x86_64-linux-gnu/libnssckbi.so
+        CI_BAK_MODULE: /usr/lib/x86_64-linux-gnu/libnssckbi.orig.so
+    - container:
+        image: debian:testing
+        cpu: 1
+        memory: 1G
+      package_install_script:
+        - apt-get update
+        - apt-get install -y curl libnss3-tools
+      env:
+        CI_DISTRO: debian testing
+        CI_MAIN_MODULE: /usr/lib/x86_64-linux-gnu/libnssckbi.so
+        CI_BAK_MODULE: /usr/lib/x86_64-linux-gnu/libnssckbi.orig.so
+    - container:
+        image: debian:unstable
+        cpu: 1
+        memory: 1G
+      package_install_script:
+        - apt-get update
+        - apt-get install -y curl libnss3-tools
+      env:
+        CI_DISTRO: debian unstable
+        CI_MAIN_MODULE: /usr/lib/x86_64-linux-gnu/libnssckbi.so
+        CI_BAK_MODULE: /usr/lib/x86_64-linux-gnu/libnssckbi.orig.so
   install_script:
     - curl -o pkcs11mod.tar.gz https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/Compile%20Go%20latest%20linux%20amd64/binaries/dist/pkcs11mod.tar.gz
     - tar -xaf ./pkcs11mod.tar.gz


### PR DESCRIPTION
NSS's `libnssckbi.so` moved between Bullseye and Bookworm.