### PR TITLE
Avoid pkcs11mod dictating where log file goes

### DIFF
--- a/p11mod/p11mod.go
+++ b/p11mod/p11mod.go
@@ -19,6 +19,7 @@ package p11mod
 
 import (
 	"errors"
+	"io"
 	"log"
 	"os"
 	"sync"
@@ -32,6 +33,8 @@ import (
 var (
 	trace bool
 
+	logfile io.Closer
+
 	highBackend    p11.Module
 	errHighBackend error
 )
@@ -42,6 +45,32 @@ func SetBackend(b p11.Module, err error) {
 }
 
 func init() {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		log.Printf("error reading config dir (will try fallback): %v", err)
+
+		dir = "."
+	}
+
+	f, err := os.OpenFile(dir+"/p11mod.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o600)
+	if err != nil {
+		log.Printf("error opening file (will try fallback): %v", err)
+
+		dir = "."
+		f, err = os.OpenFile(dir+"/p11mod.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o600)
+	}
+
+	if err != nil {
+		log.Printf("error opening file (will fallback to console logging): %v", err)
+	}
+
+	if err == nil {
+		log.SetOutput(f)
+		logfile = f
+	}
+
+	log.Println("Namecoin PKCS#11 module loading")
+
 	b := &llBackend{
 		slots:    []p11.Slot{},
 		sessions: map[pkcs11.SessionHandle]*llSession{},

--- a/pkcs11mod.go
+++ b/pkcs11mod.go
@@ -39,7 +39,6 @@ import "C"
 
 import (
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"strings"
@@ -53,37 +52,10 @@ var (
 	trace          bool
 	traceSensitive bool
 
-	logfile io.Closer
 	backend pkcs11.Ctx
 )
 
 func init() {
-	dir, err := os.UserConfigDir()
-	if err != nil {
-		log.Printf("error reading config dir (will try fallback): %v", err)
-
-		dir = "."
-	}
-
-	f, err := os.OpenFile(dir+"/pkcs11mod.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o600)
-	if err != nil {
-		log.Printf("error opening file (will try fallback): %v", err)
-
-		dir = "."
-		f, err = os.OpenFile(dir+"/pkcs11mod.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o600)
-	}
-
-	if err != nil {
-		log.Printf("error opening file (will fallback to console logging): %v", err)
-	}
-
-	if err == nil {
-		log.SetOutput(f)
-		logfile = f
-	}
-
-	log.Println("Namecoin PKCS#11 module loading")
-
 	if os.Getenv("PKCS11MOD_TRACE") == "1" {
 		trace = true
 	}

--- a/pkcs11proxy/pkcs11proxy.go
+++ b/pkcs11proxy/pkcs11proxy.go
@@ -18,6 +18,8 @@
 package main
 
 import (
+	"io"
+	"log"
 	"os"
 
 	"github.com/miekg/pkcs11"
@@ -25,11 +27,41 @@ import (
 	"github.com/namecoin/pkcs11mod"
 )
 
+var logfile io.Closer
+
 func init() {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		log.Printf("error reading config dir (will try fallback): %v", err)
+
+		dir = "."
+	}
+
+	f, err := os.OpenFile(dir+"/pkcs11proxy.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o600)
+	if err != nil {
+		log.Printf("error opening file (will try fallback): %v", err)
+
+		dir = "."
+		f, err = os.OpenFile(dir+"/pkcs11proxy.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o600)
+	}
+
+	if err != nil {
+		log.Printf("error opening file (will fallback to console logging): %v", err)
+	}
+
+	if err == nil {
+		log.SetOutput(f)
+		logfile = f
+	}
+
+	log.Println("pkcs11proxy: module loading")
+
 	backendPath := os.Getenv("PKCS11PROXY_CKBI_TARGET")
 	if backendPath == "" {
 		backendPath = "/usr/lib64/nss/libnssckbi.so"
 	}
+
+	log.Printf("pkcs11proxy: backend path: %s\n", backendPath)
 
 	backend := pkcs11.New(backendPath)
 	if backend == nil {

--- a/testdata/assert-proxy-log.bash
+++ b/testdata/assert-proxy-log.bash
@@ -11,7 +11,7 @@ then
     exit 1
 fi
 
-if [[ -e "$HOME/.config/pkcs11proxy.log" ]] || [[ -e "./pkcs11proxy.log" ]]
+if [[ -e "$HOME/.config/pkcs11proxy.log" ]] || [[ -e "./pkcs11proxy.log" ]] || [[ -e "$HOME/.config/p11mod.log" ]] || [[ -e "./p11mod.log" ]]
 then
     RESULT="present"
 else
@@ -20,6 +20,8 @@ fi
 
 rm -f "$HOME/.config/pkcs11proxy.log"
 rm -f "./pkcs11proxy.log"
+rm -f "$HOME/.config/p11mod.log"
+rm -f "./p11mod.log"
 
 if [[ "$RESULT" != "$DESIRED" ]]
 then

--- a/testdata/assert-proxy-log.bash
+++ b/testdata/assert-proxy-log.bash
@@ -11,15 +11,15 @@ then
     exit 1
 fi
 
-if [[ -e "$HOME/.config/pkcs11mod.log" ]] || [[ -e "./pkcs11mod.log" ]]
+if [[ -e "$HOME/.config/pkcs11proxy.log" ]] || [[ -e "./pkcs11proxy.log" ]]
 then
     RESULT="present"
 else
     RESULT="missing"
 fi
 
-rm -f "$HOME/.config/pkcs11mod.log"
-rm -f "./pkcs11mod.log"
+rm -f "$HOME/.config/pkcs11proxy.log"
+rm -f "./pkcs11proxy.log"
 
 if [[ "$RESULT" != "$DESIRED" ]]
 then

--- a/testdata/assert-proxy-log.ps1
+++ b/testdata/assert-proxy-log.ps1
@@ -9,15 +9,15 @@ if ( ("$desired" -ne "present" ) -and ( "$desired" -ne "missing" ) ) {
     exit 1
 }
 
-if ( ( Test-Path -Path "$Env:APPDATA/pkcs11mod.log" ) -Or ( Test-Path -Path "./pkcs11mod.log" ) ) {
+if ( ( Test-Path -Path "$Env:APPDATA/pkcs11proxy.log" ) -Or ( Test-Path -Path "./pkcs11proxy.log" ) ) {
     $result="present"
 }
 else {
     $result="missing"
 }
 
-Remove-Item -Force -ErrorAction SilentlyContinue "$Env:APPDATA/pkcs11mod.log"
-Remove-Item -Force -ErrorAction SilentlyContinue "./pkcs11mod.log"
+Remove-Item -Force -ErrorAction SilentlyContinue "$Env:APPDATA/pkcs11proxy.log"
+Remove-Item -Force -ErrorAction SilentlyContinue "./pkcs11proxy.log"
 
 if ( "$result" -ne "$desired" ) {
     Write-Host "Log test failed"

--- a/testdata/assert-proxy-log.ps1
+++ b/testdata/assert-proxy-log.ps1
@@ -9,7 +9,7 @@ if ( ("$desired" -ne "present" ) -and ( "$desired" -ne "missing" ) ) {
     exit 1
 }
 
-if ( ( Test-Path -Path "$Env:APPDATA/pkcs11proxy.log" ) -Or ( Test-Path -Path "./pkcs11proxy.log" ) ) {
+if ( ( ( Test-Path -Path "$Env:APPDATA/pkcs11proxy.log" ) -Or ( Test-Path -Path "./pkcs11proxy.log" ) ) -Or ( ( Test-Path -Path "$Env:APPDATA/p11mod.log" ) -Or ( Test-Path -Path "./p11mod.log" ) ) ) {
     $result="present"
 }
 else {
@@ -18,6 +18,8 @@ else {
 
 Remove-Item -Force -ErrorAction SilentlyContinue "$Env:APPDATA/pkcs11proxy.log"
 Remove-Item -Force -ErrorAction SilentlyContinue "./pkcs11proxy.log"
+Remove-Item -Force -ErrorAction SilentlyContinue "$Env:APPDATA/p11mod.log"
+Remove-Item -Force -ErrorAction SilentlyContinue "./p11mod.log"
 
 if ( "$result" -ne "$desired" ) {
     Write-Host "Log test failed"

--- a/testdata/dump-proxy-log-fail.bash
+++ b/testdata/dump-proxy-log-fail.bash
@@ -7,7 +7,7 @@ echo ""
 echo "!!!!! Test failed, dumping proxy log... !!!!!"
 echo ""
 
-cat "$HOME/.config/pkcs11mod.log" || true
-cat "./pkcs11mod.log" || true
+cat "$HOME/.config/pkcs11proxy.log" || true
+cat "./pkcs11proxy.log" || true
 
 exit 1

--- a/testdata/dump-proxy-log-fail.bash
+++ b/testdata/dump-proxy-log-fail.bash
@@ -9,5 +9,7 @@ echo ""
 
 cat "$HOME/.config/pkcs11proxy.log" || true
 cat "./pkcs11proxy.log" || true
+cat "$HOME/.config/p11mod.log" || true
+cat "./p11mod.log" || true
 
 exit 1

--- a/testdata/dump-proxy-log-fail.ps1
+++ b/testdata/dump-proxy-log-fail.ps1
@@ -6,5 +6,7 @@ Write-Host ""
 
 Get-Content -ErrorAction SilentlyContinue "$Env:APPDATA/pkcs11proxy.log"
 Get-Content -ErrorAction SilentlyContinue "./pkcs11proxy.log"
+Get-Content -ErrorAction SilentlyContinue "$Env:APPDATA/p11mod.log"
+Get-Content -ErrorAction SilentlyContinue "./p11mod.log"
 
 exit 1

--- a/testdata/dump-proxy-log-fail.ps1
+++ b/testdata/dump-proxy-log-fail.ps1
@@ -4,7 +4,7 @@ Write-Host ""
 Write-Host "!!!!! Test failed, dumping proxy log... !!!!!"
 Write-Host ""
 
-Get-Content -ErrorAction SilentlyContinue "$Env:APPDATA/pkcs11mod.log"
-Get-Content -ErrorAction SilentlyContinue "./pkcs11mod.log"
+Get-Content -ErrorAction SilentlyContinue "$Env:APPDATA/pkcs11proxy.log"
+Get-Content -ErrorAction SilentlyContinue "./pkcs11proxy.log"
 
 exit 1

--- a/testdata/try-tstclnt-connect.bash
+++ b/testdata/try-tstclnt-connect.bash
@@ -27,7 +27,6 @@ then
     echo "TLS test failed"
     echo "Got $RESULT, wanted $DESIRED"
     echo "$TEXTOUT"
-    cat "$HOME/pkcs11mod.log" || true
     exit 1
 fi
 
@@ -36,7 +35,6 @@ then
     echo "TLS test failed"
     echo "Missing output: $TEXTMATCH"
     echo "$TEXTOUT"
-    cat "$HOME/pkcs11mod.log" || true
     exit 1
 fi
 


### PR DESCRIPTION
This is now the responsibility of the backend, e.g. p11mod or pkcs11proxy.

Refs https://github.com/namecoin/pkcs11mod/issues/4