### PR TITLE
Avoid p11mod dictating where log file goes

### DIFF
--- a/p11mod/p11mod.go
+++ b/p11mod/p11mod.go
@@ -19,7 +19,6 @@ package p11mod
 
 import (
 	"errors"
-	"io"
 	"log"
 	"os"
 	"sync"
@@ -33,8 +32,6 @@ import (
 var (
 	trace bool
 
-	logfile io.Closer
-
 	highBackend    p11.Module
 	errHighBackend error
 )
@@ -45,32 +42,6 @@ func SetBackend(b p11.Module, err error) {
 }
 
 func init() {
-	dir, err := os.UserConfigDir()
-	if err != nil {
-		log.Printf("error reading config dir (will try fallback): %v", err)
-
-		dir = "."
-	}
-
-	f, err := os.OpenFile(dir+"/p11mod.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o600)
-	if err != nil {
-		log.Printf("error opening file (will try fallback): %v", err)
-
-		dir = "."
-		f, err = os.OpenFile(dir+"/p11mod.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o600)
-	}
-
-	if err != nil {
-		log.Printf("error opening file (will fallback to console logging): %v", err)
-	}
-
-	if err == nil {
-		log.SetOutput(f)
-		logfile = f
-	}
-
-	log.Println("Namecoin PKCS#11 module loading")
-
 	b := &llBackend{
 		slots:    []p11.Slot{},
 		sessions: map[pkcs11.SessionHandle]*llSession{},

--- a/p11proxy/p11proxy.go
+++ b/p11proxy/p11proxy.go
@@ -18,6 +18,8 @@
 package main
 
 import (
+	"io"
+	"log"
 	"os"
 
 	"github.com/miekg/pkcs11/p11"
@@ -25,11 +27,41 @@ import (
 	"github.com/namecoin/pkcs11mod/p11mod"
 )
 
+var logfile io.Closer
+
 func init() {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		log.Printf("error reading config dir (will try fallback): %v", err)
+
+		dir = "."
+	}
+
+	f, err := os.OpenFile(dir+"/p11proxy.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o600)
+	if err != nil {
+		log.Printf("error opening file (will try fallback): %v", err)
+
+		dir = "."
+		f, err = os.OpenFile(dir+"/p11proxy.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o600)
+	}
+
+	if err != nil {
+		log.Printf("error opening file (will fallback to console logging): %v", err)
+	}
+
+	if err == nil {
+		log.SetOutput(f)
+		logfile = f
+	}
+
+	log.Println("p11proxy: module loading")
+
 	backendPath := os.Getenv("P11PROXY_CKBI_TARGET")
 	if backendPath == "" {
 		backendPath = "/usr/lib64/nss/libnssckbi.so"
 	}
+
+	log.Printf("p11proxy: backend path: %s\n", backendPath)
 
 	backend, err := p11.OpenModule(backendPath)
 

--- a/testdata/assert-proxy-log.bash
+++ b/testdata/assert-proxy-log.bash
@@ -11,7 +11,7 @@ then
     exit 1
 fi
 
-if [[ -e "$HOME/.config/pkcs11proxy.log" ]] || [[ -e "./pkcs11proxy.log" ]] || [[ -e "$HOME/.config/p11mod.log" ]] || [[ -e "./p11mod.log" ]]
+if [[ -e "$HOME/.config/pkcs11proxy.log" ]] || [[ -e "./pkcs11proxy.log" ]] || [[ -e "$HOME/.config/p11proxy.log" ]] || [[ -e "./p11proxy.log" ]]
 then
     RESULT="present"
 else
@@ -20,8 +20,8 @@ fi
 
 rm -f "$HOME/.config/pkcs11proxy.log"
 rm -f "./pkcs11proxy.log"
-rm -f "$HOME/.config/p11mod.log"
-rm -f "./p11mod.log"
+rm -f "$HOME/.config/p11proxy.log"
+rm -f "./p11proxy.log"
 
 if [[ "$RESULT" != "$DESIRED" ]]
 then

--- a/testdata/assert-proxy-log.ps1
+++ b/testdata/assert-proxy-log.ps1
@@ -9,7 +9,7 @@ if ( ("$desired" -ne "present" ) -and ( "$desired" -ne "missing" ) ) {
     exit 1
 }
 
-if ( ( ( Test-Path -Path "$Env:APPDATA/pkcs11proxy.log" ) -Or ( Test-Path -Path "./pkcs11proxy.log" ) ) -Or ( ( Test-Path -Path "$Env:APPDATA/p11mod.log" ) -Or ( Test-Path -Path "./p11mod.log" ) ) ) {
+if ( ( ( Test-Path -Path "$Env:APPDATA/pkcs11proxy.log" ) -Or ( Test-Path -Path "./pkcs11proxy.log" ) ) -Or ( ( Test-Path -Path "$Env:APPDATA/p11proxy.log" ) -Or ( Test-Path -Path "./p11proxy.log" ) ) ) {
     $result="present"
 }
 else {
@@ -18,8 +18,8 @@ else {
 
 Remove-Item -Force -ErrorAction SilentlyContinue "$Env:APPDATA/pkcs11proxy.log"
 Remove-Item -Force -ErrorAction SilentlyContinue "./pkcs11proxy.log"
-Remove-Item -Force -ErrorAction SilentlyContinue "$Env:APPDATA/p11mod.log"
-Remove-Item -Force -ErrorAction SilentlyContinue "./p11mod.log"
+Remove-Item -Force -ErrorAction SilentlyContinue "$Env:APPDATA/p11proxy.log"
+Remove-Item -Force -ErrorAction SilentlyContinue "./p11proxy.log"
 
 if ( "$result" -ne "$desired" ) {
     Write-Host "Log test failed"

--- a/testdata/dump-proxy-log-fail.bash
+++ b/testdata/dump-proxy-log-fail.bash
@@ -9,7 +9,7 @@ echo ""
 
 cat "$HOME/.config/pkcs11proxy.log" || true
 cat "./pkcs11proxy.log" || true
-cat "$HOME/.config/p11mod.log" || true
-cat "./p11mod.log" || true
+cat "$HOME/.config/p11proxy.log" || true
+cat "./p11proxy.log" || true
 
 exit 1

--- a/testdata/dump-proxy-log-fail.ps1
+++ b/testdata/dump-proxy-log-fail.ps1
@@ -6,7 +6,7 @@ Write-Host ""
 
 Get-Content -ErrorAction SilentlyContinue "$Env:APPDATA/pkcs11proxy.log"
 Get-Content -ErrorAction SilentlyContinue "./pkcs11proxy.log"
-Get-Content -ErrorAction SilentlyContinue "$Env:APPDATA/p11mod.log"
-Get-Content -ErrorAction SilentlyContinue "./p11mod.log"
+Get-Content -ErrorAction SilentlyContinue "$Env:APPDATA/p11proxy.log"
+Get-Content -ErrorAction SilentlyContinue "./p11proxy.log"
 
 exit 1


### PR DESCRIPTION
This is now the responsibility of the backend, e.g. ncp11 or p11proxy.

Fixes https://github.com/namecoin/pkcs11mod/issues/4