### PR TITLE
p11trustmod: expose backend-controlled CKA_TRUSTED

### DIFF
--- a/p11trustmod/backend.go
+++ b/p11trustmod/backend.go
@@ -44,6 +44,7 @@ type CertificateData struct {
 	Label                string
 	Certificate          *x509.Certificate
 	BuiltinPolicy        bool
+	Trusted              bool
 	TrustServerAuth      uint
 	TrustClientAuth      uint
 	TrustCodeSigning     uint

--- a/p11trustmod/p11trustmod.go
+++ b/p11trustmod/p11trustmod.go
@@ -524,6 +524,8 @@ func (obj *certificateObject) Attribute(attributeType uint) ([]byte, error) {
 		return marshalAttributeValue(asn1SerialNumber), nil
 	case pkcs11.CKA_VALUE:
 		return marshalAttributeValue(obj.data.Certificate.Raw), nil
+	case pkcs11.CKA_TRUSTED:
+		return marshalAttributeValue(obj.data.Trusted), nil
 	case pkcs11.CKA_NSS_MOZILLA_CA_POLICY:
 		if obj.includeBuiltinPolicy {
 			return marshalAttributeValue(obj.data.BuiltinPolicy), nil


### PR DESCRIPTION
Adds `CKA_TRUSTED` support for certificate objects.

Some p11-kit/GnuTLS paths ask for this attribute when checking trust. pkcs11mod now returns the backend-provided `CertificateData.Trusted` value, so trust stays opt-in and is not inferred inside pkcs11mod.

Tested with:

- `go mod edit -replace github.com/miekg/pkcs11=github.com/namecoin/pkcs11@master-1.1.1.4`
- `go mod tidy`
- `go generate ./...`
- `go test ./...`